### PR TITLE
ci: add GCC compatibility gate

### DIFF
--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -10,6 +10,17 @@
 #
 # This is a REQUIRED check, via the GCC Gate job at the bottom.
 #
+# What a green run does NOT mean, so nobody reads more into it than it says:
+#   - an41908a is never built here (proprietary MPP SDK), so changes under
+#     an41908a/ get no coverage at all from this gate.
+#   - These are Debian glibc cross-compilers, not the musl OpenIPC or vendor
+#     toolchains the tools ship against. That is deliberate -- the diagnostics
+#     promoted below are language-level and libc-independent, while the real
+#     toolchains are 100 MB-3.7 GB downloads and the vendor ones are GCC
+#     4.4-6.3, far too old to catch what a modern compiler rejects. The gap
+#     this leaves is a musl-only break passing here and failing on target.
+#   - Nothing is executed. This gate compiles; it does not test.
+#
 # There is deliberately no `paths:` filter on the trigger. A workflow filtered
 # out by `paths:` does not run at all, so a required check from it would sit
 # pending forever and the pull request could never be merged. The whole repo is

--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -70,7 +70,7 @@ jobs:
           # stdio.h, and every build fails with a fatal missing-header error
           # that looks nothing like the dependency problem it actually is.
           apt-get install -y --no-install-recommends \
-            git ca-certificates \
+            bash git ca-certificates \
             gcc-arm-linux-gnueabihf libc6-dev-armhf-cross \
             gcc-mipsel-linux-gnu libc6-dev-mipsel-cross
 
@@ -78,6 +78,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cross-compile every tool
+        # Pinned explicitly. These slim images ship no bash, so without this
+        # Actions falls back to `sh -e` -- different semantics from the bash
+        # this script was written and tested against, which is exactly how the
+        # first version of this workflow passed locally and failed in CI.
+        shell: bash -eo pipefail {0}
         run: |
           set -u
           # Targeted -Werror= rather than a blanket -Werror. These sources carry
@@ -101,8 +106,13 @@ jobs:
             if $cc $FLAGS -o "/tmp/$name" "$src" 2>/tmp/err.log; then
               echo "PASS  $name ($cc)"
               # Surface the legacy warnings without failing on them, so the
-              # noise stays visible and does not quietly grow.
-              [ -s /tmp/err.log ] && sed 's/^/      /' /tmp/err.log | head -20
+              # noise stays visible and does not quietly grow. A real `if`
+              # rather than `[ -s f ] && ...`: the latter evaluates false for a
+              # tool that compiles cleanly, and under `set -e` that ends the run.
+              # head before sed so the left side cannot take SIGPIPE under pipefail.
+              if [ -s /tmp/err.log ]; then
+                head -20 /tmp/err.log | sed 's/^/      /'
+              fi
             else
               echo "FAIL  $name ($cc)"
               sed 's/^/      /' /tmp/err.log

--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -1,0 +1,151 @@
+# Do these tools still compile on the compilers people actually have?
+#
+# Every tool here was written against a vendor GCC from the 4.4-6.3 era and is
+# cross-compiled for a camera SoC, so nothing about them gets exercised by
+# simply cloning the repo. Modern compilers reject things those vendor
+# compilers accepted silently: i2c-motor called ioctl() with no declaration in
+# scope for years, which GCC 13 merely warned about and GCC 14 rejects
+# outright, and the bug was invisible until someone tried a current toolchain.
+# This workflow is that someone, on every pull request.
+#
+# This is a REQUIRED check, via the GCC Gate job at the bottom.
+#
+# There is deliberately no `paths:` filter on the trigger. A workflow filtered
+# out by `paths:` does not run at all, so a required check from it would sit
+# pending forever and the pull request could never be merged. The whole repo is
+# five C files and a build takes under a minute, so there is nothing to narrow.
+name: gcc-compat
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  # Catches toolchain rot with no pull request in sight: the tree stops
+  # building because a new GCC changed a language default, not because anyone
+  # touched the code.
+  schedule:
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gcc:
+    name: GCC ${{ matrix.gcc }}
+    # Same guard rail firmware uses: run where the minutes are free or
+    # explicitly asked for, skip unattended billed mirror runs.
+    if: >-
+      github.repository == 'OpenIPC/motors' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private)
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    strategy:
+      # Both rows should report. Which compiler broke IS the finding.
+      fail-fast: false
+      matrix:
+        include:
+          # Older row: the tree must not start depending on new-compiler
+          # behaviour that the vendor toolchains lack.
+          - gcc: 12
+            image: debian:bookworm-slim
+          # Newer row: the one that fails on constructs a modern GCC rejects.
+          # Add a newer image here as they stabilise, rather than switching to
+          # a rolling tag whose churn would produce red runs nobody caused.
+          - gcc: 14
+            image: debian:trixie-slim
+
+    steps:
+      # Before checkout: actions/checkout needs git present in the container.
+      - name: Install cross toolchains
+        run: |
+          apt-get update
+          # The libc6-dev-*-cross packages are named explicitly because they
+          # are only *recommends* of the gcc-*-cross packages: with
+          # --no-install-recommends you get a compiler that cannot find
+          # stdio.h, and every build fails with a fatal missing-header error
+          # that looks nothing like the dependency problem it actually is.
+          apt-get install -y --no-install-recommends \
+            git ca-certificates \
+            gcc-arm-linux-gnueabihf libc6-dev-armhf-cross \
+            gcc-mipsel-linux-gnu libc6-dev-mipsel-cross
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cross-compile every tool
+        run: |
+          set -u
+          # Targeted -Werror= rather than a blanket -Werror. These sources carry
+          # a lot of harmless legacy noise -- unused variables, signedness
+          # mismatches -- and blanket -Werror would fail on day one, forcing
+          # either a churn commit touching every file or switching the gate off.
+          # Promoted here are only the classes that mean the code is actually
+          # wrong, and both of the bugs this repo has already hit are in the
+          # list: implicit-function-declaration and format.
+          FLAGS="-Wall
+            -Werror=implicit-function-declaration
+            -Werror=implicit-int
+            -Werror=int-conversion
+            -Werror=incompatible-pointer-types
+            -Werror=format
+            -Werror=return-type"
+
+          rc=0
+          build() {
+            cc=$1; name=$2; src=$3
+            if $cc $FLAGS -o "/tmp/$name" "$src" 2>/tmp/err.log; then
+              echo "PASS  $name ($cc)"
+              # Surface the legacy warnings without failing on them, so the
+              # noise stays visible and does not quietly grow.
+              [ -s /tmp/err.log ] && sed 's/^/      /' /tmp/err.log | head -20
+            else
+              echo "FAIL  $name ($cc)"
+              sed 's/^/      /' /tmp/err.log
+              echo "::error::$name failed to build with $cc"
+              rc=1
+            fi
+          }
+
+          # ARM targets: Xiongmai and HiSilicon SoCs.
+          for t in xm-kmotor xm-uart camhi-motor i2c-motor; do
+            build arm-linux-gnueabihf-gcc "$t" "$t/main.c"
+          done
+
+          # ingenic-motor targets the Ingenic T31, which is MIPS little-endian,
+          # NOT ARM. Its OpenIPC toolchain is mipsel-openipc-linux-musl-.
+          build mipsel-linux-gnu-gcc ingenic-motor ingenic-motor/main.c
+
+          # an41908a is deliberately absent. It needs the proprietary HiSilicon
+          # Hi3516CV500 MPP SDK for hi_type.h/mpi_isp.h and the -lmpi -lisp link
+          # set, which is not publicly redistributable, so CI cannot build it.
+          # Changes to an41908a/ are not covered here -- build it by hand.
+          echo "SKIP  an41908a (needs proprietary Hi3516CV500 MPP SDK)"
+
+          exit $rc
+
+  # The required context. Branch protection requires this single job rather
+  # than the `GCC N` rows directly, so that adding or retiring a matrix row
+  # never requires editing branch protection to match.
+  gcc-gate:
+    name: GCC Gate
+    needs: [gcc]
+    # always() so the gate still reports a red when the matrix fails, instead
+    # of being skipped along with it and leaving the check pending.
+    if: >-
+      always() && (github.repository == 'OpenIPC/motors' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !github.event.repository.private))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the compile matrix to succeed
+        run: |
+          echo "matrix=${{ needs.gcc.result }}"
+          if [ "${{ needs.gcc.result }}" != "success" ]; then
+            echo "::error::a GCC row did not succeed"; exit 1
+          fi
+          echo "GCC Gate: pass"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is
 
-A collection of **independent, single-file C command-line tools** that drive camera motors (pan/tilt, zoom, focus, iris) on ARM IP-camera SoCs — Xiongmai, HiSilicon, Ingenic T31. There is no shared library, no top-level build, and no test suite. Each directory is a self-contained program targeting one specific hardware/driver combination, and `api/` is a design document for a future daemon that would unify them.
+A collection of **independent, single-file C command-line tools** that drive camera motors (pan/tilt, zoom, focus, iris) on IP-camera SoCs — Xiongmai, HiSilicon, Ingenic T31. There is no shared library and no top-level build. Each directory is a self-contained program targeting one specific hardware/driver combination, and `api/` is a design document for a future daemon that would unify them.
+
+There are no tests — the code only does anything when talking to real motor hardware. The one automated check is `.github/workflows/gcc-compat.yml`, which cross-compiles every tool on GCC 12 and GCC 14 and is a **required status check** (`GCC Gate`) on `master`. It is a compile gate, not a test suite: it proves the tree still builds, nothing about whether a motor moves.
 
 Because every tool talks to different vendor hardware, **the tools cannot be built or run on the development host** — they are cross-compiled for ARM and executed on a camera over SSH.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A collection of **independent, single-file C command-line tools** that drive camera motors (pan/tilt, zoom, focus, iris) on IP-camera SoCs — Xiongmai, HiSilicon, Ingenic T31. There is no shared library and no top-level build. Each directory is a self-contained program targeting one specific hardware/driver combination, and `api/` is a design document for a future daemon that would unify them.
 
-There are no tests — the code only does anything when talking to real motor hardware. The one automated check is `.github/workflows/gcc-compat.yml`, which cross-compiles every tool on GCC 12 and GCC 14 and is a **required status check** (`GCC Gate`) on `master`. It is a compile gate, not a test suite: it proves the tree still builds, nothing about whether a motor moves.
+There are no tests — the code only does anything when talking to real motor hardware. The one automated check is `.github/workflows/gcc-compat.yml`, a **required status check** (`GCC Gate`) on `master`. Know precisely what it does and does not cover:
+
+- It cross-compiles **five of the six tools** on GCC 12 and GCC 14. **`an41908a` is excluded**, because it needs the proprietary Hi3516CV500 MPP SDK — so changes under `an41908a/` get no CI coverage whatsoever and must be built by hand. A green gate says nothing about them.
+- It is a *compiler* gate, not a *toolchain* gate. It uses Debian's glibc cross-compilers (`arm-linux-gnueabihf`, `mipsel-linux-gnu`), not the musl OpenIPC or vendor toolchains these tools actually ship against. That is deliberate: the defects it exists to catch — implicit declarations, format bugs, int conversions — are language-level and libc-independent, whereas the real toolchains are 100 MB–3.7 GB downloads and the vendor ones are GCC 4.4–6.3, too old to catch what a modern compiler rejects. The gap it leaves is a musl-only build break (a header difference between musl and glibc) passing CI and failing on the real toolchain.
+- It proves the tree still compiles. It does not produce a deployable binary, and it says nothing about whether a motor moves.
 
 Because every tool talks to different vendor hardware, **the tools cannot be built or run on the development host** — they are cross-compiled for ARM and executed on a camera over SSH.
 


### PR DESCRIPTION
Adds the `GCC Gate` required check discussed after #15, mirroring the structure of `OpenIPC/firmware`'s `gcc-compat.yml`.

## Why

Every tool here targets a camera SoC and was written against a vendor GCC from the 4.4–6.3 era, so nothing about them is exercised by cloning the repo. Modern compilers reject constructs those vendor compilers accepted silently — `i2c-motor` called `ioctl()` with no declaration in scope for years, which GCC 13 only warns about and **GCC 14 rejects outright**. That went unnoticed until someone tried a current toolchain. This workflow is that someone, on every PR.

## What it builds

| Tool | Target |
|---|---|
| `xm-kmotor`, `xm-uart`, `camhi-motor`, `i2c-motor` | `arm-linux-gnueabihf-gcc` |
| `ingenic-motor` | `mipsel-linux-gnu-gcc` — the T31 is MIPS little-endian, not ARM |
| `an41908a` | **excluded**, needs the proprietary Hi3516CV500 MPP SDK |

Matrix rows are GCC 12 (`bookworm`) and GCC 14 (`trixie`): the old row guards against depending on new-compiler behaviour the vendor toolchains lack, the new row catches what a modern GCC rejects.

## Design notes

- **Targeted `-Werror=` rather than blanket `-Werror`.** These sources carry a lot of harmless legacy noise (unused variables, signedness mismatches); blanket `-Werror` would fail on day one and force either a churn commit touching every file or switching the gate off. Promoted are only classes that mean the code is genuinely wrong — including both bugs this repo has already hit, `implicit-function-declaration` and `format`. The remaining warnings are still printed, so the noise stays visible and cannot quietly grow.
- **No `paths:` filter on the trigger.** Per the lesson recorded in firmware's own `gcc-compat.yml`: a workflow filtered out by `paths:` does not run at all, so a required check from it sits pending forever and the PR can never be merged. The repo is five C files; there is nothing worth narrowing.
- **`GCC Gate` is a separate summarising job**, so adding or retiring a matrix row never requires editing branch protection to match. It uses `always()` so a failing matrix reports red rather than leaving the check pending.

## Verification

Both matrix rows were simulated locally in the exact container images before pushing:

- GCC 12 and GCC 14 rows both exit 0 on current `master`, all five tools passing.
- **The gate is not vacuous**: reverting either fix from #15 turns it red — `error: implicit declaration of function 'ioctl'` and `error: format '%s' expects a matching 'char *' argument`.
- Caught and fixed a real defect during that dry run: `--no-install-recommends` drops the `libc6-dev-*-cross` packages, leaving a compiler that cannot find `stdio.h`. They are now named explicitly.

`CLAUDE.md` is updated to describe the gate and to stop claiming the repo has no automated checks.

Once this lands I will add `GCC Gate` to the required contexts in branch protection.