### PR TITLE
xm-uart: compute the focus checksum over the bytes actually sent

### DIFF
--- a/xm-uart/main.c
+++ b/xm-uart/main.c
@@ -57,12 +57,18 @@ static void send_cmd(int fd, int panSpeed, int tiltSpeed, int zoomSpeed) {
 
 static void set_focus(int fd, bool near) {
   uint8_t command1 = 0, command2 = 0, data1 = 0, data2 = 0, checkSum = 0;
-  checkSum = (addressPTZ + command1 + command2 + data1 + data2) % 100;
 
   if (near)
     command1 = 1;
   else
     command2 = 0x80;
+
+  /* Over the bytes actually sent, AFTER the near/far bit is set. Computed
+   * before it, every focus frame carried checkSum 1, and an MCU that
+   * validates the sum (the 85H50AI zoom block does) silently discarded
+   * them — zoom moved, focus never did. near => 2, far => 29; a
+   * non-validating MCU accepts either form. */
+  checkSum = (addressPTZ + command1 + command2 + data1 + data2) % 100;
 
   uint8_t bstr[] = {SYNC,  addressPTZ, command1, command2,
                     data1, data2,      checkSum, 0x5c};


### PR DESCRIPTION
`set_focus()` computes `checkSum` from `command1 = command2 = 0` **before** setting the near/far bit, so every focus frame goes out with `checkSum` 1. An MCU that validates the sum silently discards those frames.

Found on real hardware: a XiongMai 85H50AI zoom block (hi3516ev300, freshly converted to OpenIPC — [majestic-webui#227](https://github.com/OpenIPC/majestic-webui/issues/227)). Zoom and stop moved; focus did nothing in either direction until the frames were re-sent with the checksum computed over the bytes actually transmitted — `near` → 2 (`c5 01 01 00 00 00 02 5c`), `far` → 29 (`c5 01 00 80 00 00 1d 5c`) — after which the focus motor drove both ways. The fix is this patch: move the `checkSum` computation below the near/far assignment. A non-validating MCU accepts either form, so the corrected frame is strictly better than the historical one.

Verified: the patched tool cross-compiled with the OpenIPC musl toolchain and its emitted focus frame byte-checked (`c5 01 01 00 00 00 02 5c`); the same frames were driven through the WebUI path on the 85H50AI with focus sharpness recovering across pulses. The equivalent fix is already merged in majestic-webui's shell port ([majestic-webui#258](https://github.com/OpenIPC/majestic-webui/pull/258)); OpenIPC/sandbox `scripts/pelcoD/btzoom-xm` carries the same bug and gets a matching PR.

Side observations from the same session, not addressed here: the interactive loop busy-spins after stdin EOF (poll checks `POLLIN` only; a closed pipe reports `POLLHUP`), so scripted use wants a `timeout` wrapper; and on the 85H50AI the tool exits with "UART closed" (`read()` returning 0 on the tty), which can swallow a queued cancel.