### PR TITLE
pelcodtui: add Pelco-D configuration interface

### DIFF
--- a/.github/workflows/gcc-compat.yml
+++ b/.github/workflows/gcc-compat.yml
@@ -81,7 +81,7 @@ jobs:
           # stdio.h, and every build fails with a fatal missing-header error
           # that looks nothing like the dependency problem it actually is.
           apt-get install -y --no-install-recommends \
-            bash git ca-certificates \
+            bash git ca-certificates gcc make libncurses-dev \
             gcc-arm-linux-gnueabihf libc6-dev-armhf-cross \
             gcc-mipsel-linux-gnu libc6-dev-mipsel-cross
 
@@ -140,6 +140,17 @@ jobs:
           # ingenic-motor targets the Ingenic T31, which is MIPS little-endian,
           # NOT ARM. Its OpenIPC toolchain is mipsel-openipc-linux-musl-.
           build mipsel-linux-gnu-gcc ingenic-motor ingenic-motor/main.c
+
+          # pelcodtui has host-runnable protocol, profile, state, and PTY tests.
+          # Its deployment target is ARM, but these checks exercise the same C
+          # sources without requiring camera hardware or the OpenIPC sysroot.
+          if make -C pelcodtui test; then
+            echo "PASS  pelcodtui (native tests)"
+          else
+            echo "FAIL  pelcodtui (native tests)"
+            echo "::error::pelcodtui failed to build or test"
+            rc=1
+          fi
 
           # an41908a is deliberately absent. It needs the proprietary HiSilicon
           # Hi3516CV500 MPP SDK for hi_type.h/mpi_isp.h and the -lmpi -lisp link

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repository is
 
-A collection of **independent, single-file C command-line tools** that drive camera motors (pan/tilt, zoom, focus, iris) on IP-camera SoCs — Xiongmai, HiSilicon, Ingenic T31. There is no shared library and no top-level build. Each directory is a self-contained program targeting one specific hardware/driver combination, and `api/` is a design document for a future daemon that would unify them.
+A collection of independent C tools that drive or configure camera motors
+(pan/tilt, zoom, focus, iris) on IP-camera SoCs - Xiongmai, HiSilicon, and
+Ingenic T31. There is no shared library and no top-level build. Each directory
+is self-contained, and `api/` is a design document for a future daemon that
+would unify them. Most tools are single-file hardware utilities; `pelcodtui/`
+is a multi-file ncurses application with host-runnable tests.
 
-There are no tests — the code only does anything when talking to real motor hardware. The one automated check is `.github/workflows/gcc-compat.yml`, a **required status check** (`GCC Gate`) on `master`. Know precisely what it does and does not cover:
+Most tools require real motor hardware and have no tests. `pelcodtui` tests its
+protocol, profiles, state storage, and UART output on a pseudo terminal. The
+automated check is `.github/workflows/gcc-compat.yml`, a **required status
+check** (`GCC Gate`) on `master`. Know precisely what it does and does not cover:
 
-- It cross-compiles **five of the six tools** on GCC 12 and GCC 14. **`an41908a` is excluded**, because it needs the proprietary Hi3516CV500 MPP SDK — so changes under `an41908a/` get no CI coverage whatsoever and must be built by hand. A green gate says nothing about them.
+- It cross-compiles five tools on GCC 12 and GCC 14, then builds and tests
+  `pelcodtui` natively. **`an41908a` is excluded**, because it needs the
+  proprietary Hi3516CV500 MPP SDK. Changes under `an41908a/` get no CI
+  coverage and must be built by hand. A green gate says nothing about them.
 - It is a *compiler* gate, not a *toolchain* gate. It uses Debian's glibc cross-compilers (`arm-linux-gnueabihf`, `mipsel-linux-gnu`), not the musl OpenIPC or vendor toolchains these tools actually ship against. That is deliberate: the defects it exists to catch — implicit declarations, format bugs, int conversions — are language-level and libc-independent, whereas the real toolchains are 100 MB–3.7 GB downloads and the vendor ones are GCC 4.4–6.3, too old to catch what a modern compiler rejects. The gap it leaves is a musl-only build break (a header difference between musl and glibc) passing CI and failing on the real toolchain.
-- It proves the tree still compiles. It does not produce a deployable binary, and it says nothing about whether a motor moves.
+- It proves the tree still compiles and runs `pelcodtui` host tests. It does not
+  produce a deployable binary, and it says nothing about whether a motor moves.
 
 Because every tool talks to different vendor hardware, **the tools cannot be built or run on the development host** — they are cross-compiled for ARM and executed on a camera over SSH.
 
 ## Building
 
-There is no top-level Makefile and nothing builds natively — every target is a
-cross-compile. Build per directory.
+There is no top-level Makefile. Build each tool in its directory. The legacy
+hardware tools are cross-compiled; `pelcodtui` also builds and tests natively.
+
+```sh
+cd pelcodtui && make test
+```
 
 Directories with a Makefile — `xm-kmotor/`, `xm-uart/`, `an41908a/`:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Various code to manage motor hardware
 
+## Pelco-D configuration TUI
+
+[`pelcodtui`](pelcodtui/) is an ncurses interface for Pelco-D PTZ controller
+settings and manual movement. Camera profiles describe controller-specific
+commands without hard-coding them in the application.
+
 ## Some theory behind
 
 [Basic autofocus algorithms](https://www.csie.ntu.edu.tw/~fuh/personal/Images&Recognition.Vol.9,No.4.Autofocus.pdf)

--- a/pelcodtui/.gitignore
+++ b/pelcodtui/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/build-camera/
+/pdfs/

--- a/pelcodtui/Makefile
+++ b/pelcodtui/Makefile
@@ -1,0 +1,55 @@
+CC ?= cc
+CFLAGS ?= -O2 -Wall -Wextra -Werror
+CPPFLAGS += -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200809L -Isrc
+NCURSES_LIBS ?= -lncurses
+PREFIX ?= /usr
+SYSCONFDIR ?= /etc
+BUILD := build
+CORE := $(BUILD)/profile.o $(BUILD)/pelco.o $(BUILD)/state.o
+UI := $(BUILD)/tui.o $(BUILD)/tui_menus.o
+CAMERA_BUILD := build-camera
+SIBLING_CAMERA_CC := ../../firmware/output/host/bin/arm-openipc-linux-musleabi-gcc
+CAMERA_CC ?= $(if $(wildcard $(SIBLING_CAMERA_CC)),$(SIBLING_CAMERA_CC),arm-openipc-linux-musleabi-gcc)
+CAMERA_HOST ?= 192.168.1.199
+CAMERA_USER ?= root
+
+.PHONY: all clean test install camera deploy
+all: $(BUILD)/pelcodtui
+
+$(BUILD):
+	mkdir -p $@
+
+$(BUILD)/%.o: src/%.c src/pelcodtui.h | $(BUILD)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+$(BUILD)/main.o $(UI): src/tui_internal.h
+
+$(BUILD)/pelcodtui: $(BUILD)/main.o $(UI) $(CORE)
+	$(CC) $(LDFLAGS) $^ $(NCURSES_LIBS) -o $@
+
+$(BUILD)/test_core: tests/test_core.c $(CORE)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^ -lutil -o $@
+
+test: $(BUILD)/pelcodtui $(BUILD)/test_core
+	@for profile in cameras/*.conf; do \
+		$(BUILD)/pelcodtui --validate "$$profile" | grep -qx 'profile valid' || exit 1; \
+		$(BUILD)/test_core "$$profile" || exit 1; \
+	done
+	! grep -Eq 'preset_(set|call) (88|95|96|97|98|150|151|153|158|159)(;|$$)' cameras/*.conf
+
+install: $(BUILD)/pelcodtui
+	install -D -m 0755 $< $(DESTDIR)$(PREFIX)/bin/pelcodtui
+	install -d $(DESTDIR)$(SYSCONFDIR)/pelcodtui/cameras
+	install -m 0644 cameras/*.conf $(DESTDIR)$(SYSCONFDIR)/pelcodtui/cameras/
+
+clean:
+	rm -rf $(BUILD)
+
+camera:
+	$(MAKE) BUILD=$(CAMERA_BUILD) CC=$(CAMERA_CC) all
+
+deploy: camera
+	CAMERA_HOST='$(CAMERA_HOST)' CAMERA_USER='$(CAMERA_USER)' \
+		CAMERA_PASSWORD='$(CAMERA_PASSWORD)' CAMERA_BUILD='$(CAMERA_BUILD)' \
+		CAMERA_CC='$(CAMERA_CC)' CAMERA_INSECURE_SSH='$(CAMERA_INSECURE_SSH)' \
+		./scripts/deploy-camera.sh

--- a/pelcodtui/README.md
+++ b/pelcodtui/README.md
@@ -1,0 +1,63 @@
+# pelcodtui
+
+`pelcodtui` is a standalone ncurses interface for Pelco-D camera controllers.
+It sends UART commands directly and uses camera templates to describe autonomous
+controller settings.
+
+Pelco-D does not return these settings. The TUI therefore shows the last command
+sent and its timestamp. It never presents saved values as confirmed camera state.
+
+<img width="2548" height="1335" alt="image" src="https://github.com/user-attachments/assets/4fb2e6ad-354b-4a01-ae46-66da988db382" />
+
+
+## Build and run
+
+```sh
+make test
+./build/pelcodtui --dry-run --profiles-dir ./cameras --state /tmp/pelcodtui-state.conf
+```
+
+Camera commands in `--dry-run` mode do not use the hardware lock or update
+command history.
+
+Install on a camera with `make DESTDIR=/path/to/rootfs install`. The default
+connection for the bundled P35 HiEasy, H07 HiEasy, and legacy P6SLite profiles
+is `/dev/ttyAMA0`, 115200 baud, address 1.
+The program shares `/tmp/btzoom.lock` with the OpenIPC WebUI and keeps the lock
+directory empty for compatibility with `btzoom`. An empty lock older than 60
+seconds is treated as stale and may be recovered.
+
+Build and deploy over SSH:
+
+```sh
+CAMERA_PASSWORD='your-password' make deploy
+```
+
+Override the defaults with `CAMERA_HOST`, `CAMERA_USER`, or `CAMERA_CC`.
+The build first looks for an OpenIPC firmware checkout at `../../firmware`,
+then falls back to finding `arm-openipc-linux-musleabi-gcc` on `PATH`.
+The camera deploy bundles ncurses and its terminal definitions under
+`/usr/lib/pelcodtui`. Override their sources with `CAMERA_NCURSES_LIB` and
+`CAMERA_TERMINFO_DIR` when needed. By default, deployment gets both paths from
+the cross-compiler sysroot reported by `CAMERA_CC -print-sysroot`.
+SSH host-key checks remain enabled. Set `CAMERA_INSECURE_SSH=1` only for a
+camera whose host key you cannot store or check.
+Deployment replaces the binary and installs all shipped templates, but preserves
+`/etc/pelcodtui/state.conf`.
+
+The profile comments identify the source manuals and note conflicting ranges.
+The PDF archive used to prepare them is local reference material and is not
+included in the repository.
+
+Keys: arrows select settings and Enter opens or applies them. Preset control is
+the first menu item and TUI pulse settings are the last. WASD moves pan/tilt,
+Z/X controls zoom, N/F controls focus, Space sends STOP, and Q exits.
+
+## Safety
+
+Factory reset, preset deletion, and pan/tilt correction require confirmation.
+Raw preset control also confirms documented destructive commands in known
+camera profiles. Unknown-camera mode keeps unrestricted preset access.
+Movement commands are timed and finish with three STOP frames at 10 ms spacing.
+Press the same movement key again before it stops to add another pulse, up to
+five seconds total.

--- a/pelcodtui/cameras/h07-hieasy.conf
+++ b/pelcodtui/cameras/h07-hieasy.conf
@@ -1,0 +1,291 @@
+# Based on: H07-HiEasyPTZCAMERAManul-p02050607.pdf,
+# Camera port Manual.pdf
+# and supplier instructions
+[profile]
+schema_version=1
+id=h07-hieasy
+name=H07 HiEasy
+description=Newer HiEasy H07 PTZ and lens-controller commands
+dangerous_call=100,106,140,252
+dangerous_set=107,253
+
+[uart]
+device=/dev/ttyAMA0
+baud=115200
+address=1
+
+[menu.presets]
+label=Presets
+items=__preset_control,delete_all_presets
+
+[menu.motion]
+label=Manual motion
+items=manual_pan_speed,manual_tilt_speed
+
+[menu.cruise]
+label=Cruise
+items=start_cruise,cruise_speed,cruise_dwell
+
+[menu.scan]
+label=Scan and limits
+items=start_auto_scan,auto_scan_speed,set_left_limit,set_right_limit,start_limit_scan,limit_scan_speed
+
+[menu.idle]
+label=Idle and recovery
+items=idle_function,disable_idle,idle_delay,recovery_delay
+
+[menu.lens]
+label=Lens
+items=lens_speed_match,af_trigger,min_focus_distance,learn_lens_curve
+
+[menu.accessories]
+label=Accessories
+items=ir_brightness,wiper,defog,defog_time,open_osd
+
+[menu.maintenance]
+label=Maintenance
+items=factory_reset,reboot_controller
+
+[menu.application]
+label=Application
+items=__tui_settings
+
+[action.delete_all_presets]
+label=Delete all presets
+description=Delete all presets using H07 command 100 Call; the table also mentions 140 Call.
+confirm=true
+warning=Delete all stored preset positions?
+command=preset_call 100
+
+[setting.manual_pan_speed]
+label=Manual pan speed
+description=Set manual pan speed from 1 through 10.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=level
+command=preset_set 160; preset_set $value
+
+[setting.manual_tilt_speed]
+label=Manual tilt speed
+description=Set manual tilt speed from 1 through 10.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=level
+command=preset_set 161; preset_set $value
+
+[action.start_cruise]
+label=Start cruise
+description=Start the H07 preset cruise.
+command=preset_call 101
+
+[setting.cruise_speed]
+label=Cruise speed
+description=Set cruise speed from 1 through 10.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=level
+command=preset_set 115; preset_set $value
+
+[setting.cruise_dwell]
+label=Cruise dwell time
+description=Set dwell time using the conservative 3..10 second range in the H07 instructions.
+type=number
+default=5
+min=3
+max=10
+step=1
+unit=seconds
+command=preset_set 123; preset_set $value
+
+[action.start_auto_scan]
+label=Start 360-degree scan
+description=Start clockwise automatic scanning.
+command=preset_call 120
+
+[setting.auto_scan_speed]
+label=Automatic scan speed
+description=Set automatic scan speed from 1 through 10.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=level
+command=preset_set 121; preset_set $value
+
+[action.set_left_limit]
+label=Set left limit here
+description=Store the current position as the left scan limit.
+command=preset_set 81
+
+[action.set_right_limit]
+label=Set right limit here
+description=Store the current position as the right scan limit.
+command=preset_set 82
+
+[action.start_limit_scan]
+label=Start limit scan
+description=Start scanning between the stored limits.
+command=preset_call 83
+
+[setting.limit_scan_speed]
+label=Limit scan speed
+description=Use the H07 instruction range 1..10; its summary table conflicts and says 1..40.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=level
+command=preset_set 141; preset_set $value
+
+[setting.idle_function]
+label=Set and enable idle function
+description=Set the preset or autonomous command used after the idle delay.
+type=number
+default=1
+min=1
+max=255
+step=1
+unit=preset
+command=preset_set 131; preset_call $value
+
+[action.disable_idle]
+label=Disable idle action
+description=Turn off the configured H07 idle action.
+command=preset_call 131
+
+[setting.idle_delay]
+label=Idle delay
+description=Set idle delay from 1 through 30 minutes.
+type=number
+default=5
+min=1
+max=30
+step=1
+unit=minutes
+command=preset_set 132; preset_set $value
+
+[setting.recovery_delay]
+label=Automatic recovery delay
+description=Set automatic recovery time from 1 through 10 minutes.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=minutes
+command=preset_set 126; preset_set $value
+
+[setting.lens_speed_match]
+label=Lens and PTZ speed matching
+description=Enable or disable zoom-dependent PTZ speed matching.
+type=toggle
+default=on
+options=off,on
+option.off.label=Off
+option.off.command=preset_set 108
+option.on.label=On
+option.on.command=preset_call 108
+
+[setting.af_trigger]
+label=Controller autofocus trigger
+description=Select which movement triggers the H07 lens controller autofocus.
+type=choice
+default=zoom
+options=zoom,ptz,video
+option.zoom.label=Zoom only
+option.zoom.command=preset_set 250; preset_call 1
+option.ptz.label=Pan tilt or zoom
+option.ptz.command=preset_set 250; preset_call 2
+option.video.label=PTZ or video change
+option.video.command=preset_set 250; preset_call 3
+
+[setting.min_focus_distance]
+label=Minimum focus distance
+description=Set lens minimum focus distance. Infinity value 4 comes from Camera port Manual.pdf.
+type=choice
+default=3m
+options=1_5m,3m,6m,infinity
+option.1_5m.label=1.5 metres
+option.1_5m.command=preset_set 251; preset_call 1
+option.3m.label=3 metres
+option.3m.command=preset_set 251; preset_call 2
+option.6m.label=6 metres
+option.6m.command=preset_set 251; preset_call 3
+option.infinity.label=Infinity
+option.infinity.command=preset_set 251; preset_call 4
+
+[action.learn_lens_curve]
+label=Learn lens curve
+description=Run the MS41919 and STM32 sequence documented in Camera port Manual.pdf as commands 253 and 252.
+confirm=true
+warning=Aim the camera at an object at least 50 metres away. Learning moves the lens and takes several seconds. Normal operation resumes after learning is complete. Continue?
+command=preset_set 253; preset_call 252
+
+# Command 122 was confirmed by the supplier for H07.
+[setting.ir_brightness]
+label=IR brightness
+description=Set IR brightness in 10 percent steps. The default level 8 is 80 percent of maximum brightness.
+type=number
+default=8
+min=1
+max=10
+step=1
+unit=10 percent
+command=preset_set 122; preset_set $value
+
+[action.wiper]
+label=Run wiper
+description=Run the optional wiper for its documented three cycles.
+command=preset_call 71
+
+[setting.defog]
+label=Defog function
+description=Enable or disable the optional internal defog function.
+type=toggle
+default=off
+options=off,on
+option.off.label=Off
+option.off.command=preset_set 72
+option.on.label=On
+option.on.command=preset_call 72
+
+[setting.defog_time]
+label=Defog duration
+description=Set optional defog operating time from 1 through 24 hours.
+type=number
+default=1
+min=1
+max=24
+step=1
+unit=hours
+command=preset_set 73; preset_set $value
+
+[action.open_osd]
+label=Open controller OSD menu
+description=Open the optional controller menu operated with PTZ directions.
+command=preset_call 80
+
+[action.factory_reset]
+label=Factory-reset PTZ controller
+description=Restore H07 controller factory settings.
+confirm=true
+warning=Reset all PTZ controller settings and presets?
+command=preset_call 106; preset_call 64
+
+[action.reboot_controller]
+label=Reboot lens and PTZ controller
+description=Run the documented H07 lens and speed-dome reboot sequence.
+confirm=true
+warning=Reboot the lens and PTZ controller?
+command=preset_set 107; preset_call 64

--- a/pelcodtui/cameras/p35-hieasy.conf
+++ b/pelcodtui/cameras/p35-hieasy.conf
@@ -1,0 +1,161 @@
+# References: P35-HiEasyManual.pdf, Part 2 and Part 3 command table.
+# UART default is the live tested OpenIPC Pelco-D connection.
+[profile]
+schema_version=1
+id=p35-hieasy
+name=P35 HiEasy
+description=Older HiEasy P35 PTZ controller commands
+dangerous_call=33,106
+dangerous_set=107
+
+[uart]
+device=/dev/ttyAMA0
+baud=115200
+address=1
+
+[menu.presets]
+label=Presets
+items=__preset_control,delete_all_presets
+
+[menu.cruise]
+label=Cruise
+items=start_cruise,cruise_speed,cruise_dwell
+
+[menu.scan]
+label=Scan and limits
+items=set_left_limit,set_right_limit,start_limit_scan,limit_scan_speed
+
+[menu.idle]
+label=Idle and home
+items=idle_enabled,idle_target,idle_delay,set_home,disable_home
+
+[menu.maintenance]
+label=Maintenance
+items=factory_reset,reboot_controller
+
+[menu.application]
+label=Application
+items=__tui_settings
+
+[action.delete_all_presets]
+label=Delete all presets
+description=Delete every stored preset using P35 command 33 Call.
+confirm=true
+warning=Delete all stored preset positions?
+command=preset_call 33
+
+[action.start_cruise]
+label=Start cruise
+description=Start the stored preset cruise.
+command=preset_call 101
+
+[setting.cruise_speed]
+label=Cruise speed
+description=Set cruise speed from 1 through 10.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=level
+command=preset_set 115; preset_set $value
+
+[setting.cruise_dwell]
+label=Cruise dwell time
+description=Select one of the P35 fixed dwell-time commands.
+type=choice
+default=4s
+options=4s,6s,8s,10s,12s
+option.4s.label=4 seconds
+option.4s.command=preset_set 51
+option.6s.label=6 seconds
+option.6s.command=preset_set 52
+option.8s.label=8 seconds
+option.8s.command=preset_set 53
+option.10s.label=10 seconds
+option.10s.command=preset_set 54
+option.12s.label=12 seconds
+option.12s.command=preset_set 55
+
+[action.set_left_limit]
+label=Set left limit here
+description=Store the current position as the left scan limit.
+command=preset_set 81
+
+[action.set_right_limit]
+label=Set right limit here
+description=Store the current position as the right scan limit.
+command=preset_set 82
+
+[action.start_limit_scan]
+label=Start limit scan
+description=Start scanning between the stored limits.
+command=preset_call 83
+
+[setting.limit_scan_speed]
+label=Limit scan speed
+description=Set P35 area-scan speed from 1 through 64.
+type=number
+default=20
+min=1
+max=64
+step=1
+unit=level
+command=preset_set 111; preset_set $value
+
+[setting.idle_enabled]
+label=Idle action
+description=Enable or disable the P35 idle action.
+type=toggle
+default=off
+options=off,on
+option.off.label=Off
+option.off.command=preset_set 105
+option.on.label=On
+option.on.command=preset_call 105
+
+[setting.idle_target]
+label=Idle target
+description=Choose the documented action used after the idle delay.
+type=choice
+default=home
+options=home,limit_scan
+option.home.label=Preset 1 home
+option.home.command=preset_call 201
+option.limit_scan.label=Limit scan
+option.limit_scan.command=preset_call 103
+
+[setting.idle_delay]
+label=Idle delay
+description=Set the P35 idle delay from 1 through 254 seconds.
+type=number
+default=90
+min=1
+max=254
+step=1
+unit=seconds
+command=preset_set 117; preset_set $value
+
+[action.set_home]
+label=Set and enable home here
+description=Store the current position as home and enable return home.
+command=preset_set 125
+
+[action.disable_home]
+label=Disable home position
+description=Disable the P35 home position.
+command=preset_call 125
+
+[action.factory_reset]
+label=Factory-reset PTZ controller
+description=Restore factory settings using the documented P35 sequence.
+confirm=true
+warning=Reset all PTZ controller settings and presets?
+command=preset_call 106; preset_call 64
+
+[action.reboot_controller]
+label=Reboot lens and PTZ controller
+description=Run the documented P35 lens and speed-dome reboot sequence.
+confirm=true
+warning=Reboot the lens and PTZ controller?
+command=preset_set 107; preset_call 64

--- a/pelcodtui/cameras/p6slite.conf
+++ b/pelcodtui/cameras/p6slite.conf
@@ -1,0 +1,282 @@
+[profile]
+schema_version=1
+id=p6slite
+name=P6SLite
+description=Autonomous features documented in P6SLite Manual 20210331
+dangerous_call=100,106
+dangerous_set=107
+
+[uart]
+device=/dev/ttyAMA0
+baud=115200
+address=1
+
+[menu.presets]
+label=Presets
+items=__preset_control,delete_all_presets
+
+[menu.cruise]
+label=Cruise
+items=cruise_group,cruise_speed,cruise_dwell
+
+[menu.scan]
+label=Scan and limits
+items=auto_scan,auto_scan_speed,set_left_limit,set_right_limit,start_limit_scan,limit_scan_speed
+
+[menu.idle]
+label=Idle and home
+items=idle_enabled,idle_function,idle_delay,set_home,delete_home,home_delay
+
+[menu.ir]
+label=Infrared lighting
+items=ir_mode,ir_threshold,ir_brightness,set_beam_switch,set_full_ir
+
+[menu.lens]
+label=Lens
+items=lens_speed_match,af_trigger,min_focus_distance
+
+[menu.maintenance]
+label=Maintenance
+items=pan_tilt_correction,factory_reset
+
+[menu.application]
+label=Application
+items=__tui_settings
+
+[setting.auto_scan]
+label=Auto scan
+description=Start autonomous 360 or 355 degree clockwise scanning.
+type=choice
+default=start
+options=start
+option.start.label=Start
+option.start.command=preset_call 120
+
+[setting.auto_scan_speed]
+label=Auto scan speed
+description=Set automatic scan speed in ten-percent steps.
+type=number
+default=8
+min=1
+max=10
+step=1
+unit=10 percent
+command=preset_set 121; preset_set $value
+
+[setting.cruise_group]
+label=Start cruise group
+description=Start stored presets 1-16, 17-32, or 33-48.
+type=choice
+default=first
+options=first,second,third
+option.first.label=Presets 1-16
+option.first.command=preset_call 101
+option.second.label=Presets 17-32
+option.second.command=preset_call 102
+option.third.label=Presets 33-48
+option.third.command=preset_call 103
+
+[setting.cruise_speed]
+label=Cruise speed
+description=Set autonomous cruise speed. The PDF text says command 115; its summary column incorrectly says 150.
+type=number
+default=8
+min=1
+max=10
+step=1
+unit=10 percent
+command=preset_set 115; preset_set $value
+
+[setting.cruise_dwell]
+label=Cruise dwell time
+description=Set how long the controller remains at each cruise preset.
+type=number
+default=5
+min=3
+max=10
+step=1
+unit=seconds
+command=preset_set 123; preset_set $value
+
+[action.set_left_limit]
+label=Set left limit here
+description=Store the current pan position as the left scan limit.
+command=preset_set 81
+
+[action.set_right_limit]
+label=Set right limit here
+description=Store the current pan position as the right scan limit.
+command=preset_set 82
+
+[action.start_limit_scan]
+label=Start limit scan
+description=Start autonomous scanning between the stored limits.
+command=preset_call 83
+
+[setting.limit_scan_speed]
+label=Limit scan speed
+description=Set left-right limit scan speed in ten-percent steps.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=10 percent
+command=preset_set 141; preset_set $value
+
+[setting.idle_enabled]
+label=Idle action
+description=Enable or disable the autonomous idle action.
+type=toggle
+default=off
+options=off,on
+option.off.label=Off
+option.off.command=preset_set 130
+option.on.label=On
+option.on.command=preset_call 130
+
+[setting.idle_function]
+label=Idle function preset
+description=Select the preset or autonomous function called after the idle delay.
+type=number
+default=1
+min=1
+max=255
+step=1
+unit=preset
+command=preset_set 131; preset_call $value
+
+[setting.idle_delay]
+label=Idle delay
+description=Set the delay before the autonomous idle action starts.
+type=number
+default=5
+min=1
+max=30
+step=1
+unit=minutes
+command=preset_set 132; preset_set $value
+
+[action.set_home]
+label=Set and enable home here
+description=Store the current position as the autonomous home position.
+command=preset_set 125
+
+[action.delete_home]
+label=Delete home position
+description=Delete the stored autonomous home position.
+command=preset_call 125
+
+[setting.home_delay]
+label=Home delay
+description=Set the standby time before return to the home position.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=minutes
+command=preset_set 126; preset_set $value
+
+[setting.ir_mode]
+label=IR light mode
+description=Select automatic, forced-on night, or forced-off day mode.
+type=choice
+default=auto
+options=auto,on,off
+option.auto.label=Automatic
+option.auto.command=preset_call 137
+option.on.label=Forced on
+option.on.command=preset_call 138
+option.off.label=Forced off
+option.off.command=preset_call 139
+
+[setting.ir_threshold]
+label=IR detection threshold
+description=Set ambient-light threshold from approximately 0.1 to 1.0 lux.
+type=number
+default=5
+min=1
+max=10
+step=1
+unit=0.1 lux
+command=preset_set 91; preset_set $value
+
+[setting.ir_brightness]
+label=IR brightness
+description=Set all-lamp brightness in ten-percent steps.
+type=number
+default=8
+min=1
+max=10
+step=1
+unit=10 percent
+command=preset_set 122; preset_set $value
+
+[action.set_beam_switch]
+label=Set near/far beam switch here
+description=Store the zoom position where the near and far IR beams switch.
+command=preset_call 92
+
+[action.set_full_ir]
+label=Set full-IR position here
+description=Store the position where near and far IR lamps operate together.
+command=preset_call 93
+
+[setting.lens_speed_match]
+label=Lens and PTZ speed matching
+description=Enable or disable automatic matching between zoom and PTZ speed.
+type=toggle
+default=on
+options=off,on
+option.off.label=Off
+option.off.command=preset_set 108
+option.on.label=On
+option.on.command=preset_call 108
+
+[setting.af_trigger]
+label=Controller autofocus trigger
+description=Select which controller activity triggers its built-in autofocus behavior.
+type=choice
+default=zoom
+options=zoom,ptz,video
+option.zoom.label=Zoom only
+option.zoom.command=preset_set 77; preset_call 1
+option.ptz.label=Pan tilt or zoom
+option.ptz.command=preset_set 77; preset_call 2
+option.video.label=PTZ or video change
+option.video.command=preset_set 77; preset_call 3
+
+[setting.min_focus_distance]
+label=Minimum focus distance
+description=Set the controller minimum focus distance.
+type=choice
+default=3m
+options=1_5m,3m,6m
+option.1_5m.label=1.5 metres
+option.1_5m.command=preset_set 78; preset_call 1
+option.3m.label=3 metres
+option.3m.command=preset_set 78; preset_call 2
+option.6m.label=6 metres
+option.6m.command=preset_set 78; preset_call 3
+
+[action.delete_all_presets]
+label=Delete all presets
+description=Delete every stored preset position.
+confirm=true
+warning=Delete all stored preset positions?
+command=preset_call 100
+
+[action.pan_tilt_correction]
+label=Run pan tilt correction
+description=Start the controller pan and tilt correction procedure.
+confirm=true
+warning=The camera can move through its full range.
+command=preset_set 107; preset_call 64
+
+[action.factory_reset]
+label=Factory-reset PTZ controller
+description=Restore the controller factory settings.
+confirm=true
+warning=Reset all PTZ controller settings and presets?
+command=preset_call 106; preset_call 64

--- a/pelcodtui/scripts/deploy-camera.sh
+++ b/pelcodtui/scripts/deploy-camera.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+set -eu
+
+host=${CAMERA_HOST:-192.168.1.199}
+user=${CAMERA_USER:-root}
+build=${CAMERA_BUILD:-build-camera}
+camera_cc=${CAMERA_CC:-arm-openipc-linux-musleabi-gcc}
+target="$user@$host"
+
+if ! command -v "$camera_cc" >/dev/null 2>&1; then
+	echo "camera compiler not found: $camera_cc" >&2
+	echo "set CAMERA_CC to the OpenIPC cross-compiler path" >&2
+	exit 1
+fi
+
+sysroot=${CAMERA_SYSROOT:-$("$camera_cc" -print-sysroot)}
+terminfo_dir=${CAMERA_TERMINFO_DIR:-$sysroot/usr/share/terminfo}
+ncurses_lib=${CAMERA_NCURSES_LIB:-}
+if [ -z "$ncurses_lib" ]; then
+	for candidate in "$sysroot"/usr/lib/libncurses.so.6.* "$sysroot"/usr/lib/libncurses.so.6; do
+		if [ -f "$candidate" ]; then
+			ncurses_lib=$candidate
+			break
+		fi
+	done
+fi
+
+if [ ! -x "$build/pelcodtui" ]; then
+	echo "missing camera binary: $build/pelcodtui" >&2
+	exit 1
+fi
+
+if [ ! -f "$ncurses_lib" ]; then
+	echo "missing camera ncurses library under: $sysroot/usr/lib" >&2
+	echo "set CAMERA_NCURSES_LIB to override it" >&2
+	exit 1
+fi
+
+for entry in x/xterm-256color x/xterm v/vt100; do
+	if [ ! -f "$terminfo_dir/$entry" ]; then
+		echo "missing camera terminfo entry: $terminfo_dir/$entry" >&2
+		exit 1
+	fi
+done
+
+if [ -n "${CAMERA_PASSWORD:-}" ]; then
+	command -v sshpass >/dev/null 2>&1 || {
+		echo "CAMERA_PASSWORD requires sshpass" >&2
+		exit 1
+	}
+fi
+
+run_ssh() {
+	if [ "${CAMERA_INSECURE_SSH:-0}" = 1 ]; then
+		set -- -o StrictHostKeyChecking=no "$@"
+	fi
+	if [ -n "${CAMERA_PASSWORD:-}" ]; then
+		sshpass -p "$CAMERA_PASSWORD" ssh "$@"
+	else
+		ssh "$@"
+	fi
+}
+
+run_scp() {
+	if [ "${CAMERA_INSECURE_SSH:-0}" = 1 ]; then
+		set -- -o StrictHostKeyChecking=no "$@"
+	fi
+	if [ -n "${CAMERA_PASSWORD:-}" ]; then
+		sshpass -p "$CAMERA_PASSWORD" scp -O "$@"
+	else
+		scp -O "$@"
+	fi
+}
+
+run_ssh "$target" \
+	'rm -rf /tmp/pelcodtui-cameras.new /tmp/pelcodtui-runtime /tmp/pelcodtui-backup && mkdir -p /etc/pelcodtui /tmp/pelcodtui-cameras.new /tmp/pelcodtui-runtime/terminfo/x /tmp/pelcodtui-runtime/terminfo/v && rm -f /tmp/pelcodtui.new /tmp/pelcodtui-launcher.new'
+run_scp "$build/pelcodtui" "$target:/tmp/pelcodtui.new"
+run_scp "$ncurses_lib" "$target:/tmp/pelcodtui-runtime/libncurses.so.6.4"
+run_scp "$terminfo_dir/x/xterm-256color" "$target:/tmp/pelcodtui-runtime/terminfo/x/xterm-256color"
+run_scp "$terminfo_dir/x/xterm" "$target:/tmp/pelcodtui-runtime/terminfo/x/xterm"
+run_scp "$terminfo_dir/v/vt100" "$target:/tmp/pelcodtui-runtime/terminfo/v/vt100"
+run_scp cameras/*.conf "$target:/tmp/pelcodtui-cameras.new/"
+run_scp scripts/pelcodtui-camera "$target:/tmp/pelcodtui-launcher.new"
+run_ssh "$target" '
+	chmod 0755 /tmp/pelcodtui.new &&
+	ln -sf libncurses.so.6.4 /tmp/pelcodtui-runtime/libncurses.so.6 &&
+	for profile in /tmp/pelcodtui-cameras.new/*.conf; do
+		LD_LIBRARY_PATH=/tmp/pelcodtui-runtime /tmp/pelcodtui.new --validate "$profile" || exit 1
+	done || exit 1
+	mkdir -p /tmp/pelcodtui-backup
+	[ ! -e /usr/lib/pelcodtui ] || cp -a /usr/lib/pelcodtui /tmp/pelcodtui-backup/runtime
+	[ ! -e /usr/bin/pelcodtui ] || cp -a /usr/bin/pelcodtui /tmp/pelcodtui-backup/launcher
+	[ ! -e /etc/pelcodtui/cameras ] || cp -a /etc/pelcodtui/cameras /tmp/pelcodtui-backup/cameras
+	install_new() {
+		rm -rf /usr/lib/pelcodtui || return 1
+		mkdir -p /usr/lib/pelcodtui || return 1
+		mv /tmp/pelcodtui.new /usr/lib/pelcodtui/pelcodtui || return 1
+		mv /tmp/pelcodtui-runtime/libncurses.so.6.4 /usr/lib/pelcodtui/libncurses.so.6.4 || return 1
+		mv /tmp/pelcodtui-runtime/terminfo /usr/lib/pelcodtui/terminfo || return 1
+		ln -sf libncurses.so.6.4 /usr/lib/pelcodtui/libncurses.so.6 || return 1
+		mv /tmp/pelcodtui-launcher.new /usr/bin/pelcodtui || return 1
+		chmod 0755 /usr/lib/pelcodtui/pelcodtui /usr/bin/pelcodtui || return 1
+		rm -rf /etc/pelcodtui/cameras || return 1
+		mv /tmp/pelcodtui-cameras.new /etc/pelcodtui/cameras || return 1
+		chmod 0644 /etc/pelcodtui/cameras/*.conf || return 1
+		for profile in /etc/pelcodtui/cameras/*.conf; do /usr/bin/pelcodtui --validate "$profile" || return 1; done
+	}
+	if ! install_new; then
+		rm -rf /usr/lib/pelcodtui /usr/bin/pelcodtui /etc/pelcodtui/cameras
+		[ ! -e /tmp/pelcodtui-backup/runtime ] || mv /tmp/pelcodtui-backup/runtime /usr/lib/pelcodtui
+		[ ! -e /tmp/pelcodtui-backup/launcher ] || mv /tmp/pelcodtui-backup/launcher /usr/bin/pelcodtui
+		[ ! -e /tmp/pelcodtui-backup/cameras ] || mv /tmp/pelcodtui-backup/cameras /etc/pelcodtui/cameras
+		echo "deployment failed; previous installation restored" >&2
+		exit 1
+	fi
+	rm -rf /tmp/pelcodtui-backup /tmp/pelcodtui-cameras.new /tmp/pelcodtui-runtime
+'
+
+echo "deployed pelcodtui to $target"
+echo "saved state preserved at /etc/pelcodtui/state.conf"

--- a/pelcodtui/scripts/pelcodtui-camera
+++ b/pelcodtui/scripts/pelcodtui-camera
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+LD_LIBRARY_PATH=/usr/lib/pelcodtui${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+TERMINFO=/usr/lib/pelcodtui/terminfo
+export LD_LIBRARY_PATH
+export TERMINFO
+
+exec /usr/lib/pelcodtui/pelcodtui "$@"

--- a/pelcodtui/src/main.c
+++ b/pelcodtui/src/main.c
@@ -1,0 +1,105 @@
+#include "tui_internal.h"
+#include <curses.h>
+#include <locale.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static volatile sig_atomic_t shutdown_signal;
+static void request_shutdown(int signal) { shutdown_signal = signal; }
+
+static int generic_tui(struct pct_ui_context *ui, bool dry_run) {
+  struct pct_transport t = {.baud = 115200, .address = 1,
+      .sequence_delay_ms = 150, .stop_repeat = 3, .stop_delay_ms = 10,
+      .dry_run = dry_run};
+  snprintf(t.device, sizeof(t.device), "/dev/ttyAMA0");
+  return pct_ui_preset_menu(ui, &t, true, NULL);
+}
+
+static void configure_transport(struct pct_transport *t,
+                                const struct pct_profile *p, bool dry_run) {
+  *t = (struct pct_transport){.baud = 115200, .address = 1,
+      .sequence_delay_ms = 150, .stop_repeat = 3, .stop_delay_ms = 10,
+      .dry_run = dry_run};
+  snprintf(t->device, sizeof(t->device), "%s",
+           pct_ui_nz(pct_get(p, "uart", "device"), "/dev/ttyAMA0"));
+  if (pct_get(p, "uart", "baud"))
+    t->baud = atoi(pct_get(p, "uart", "baud"));
+  if (pct_get(p, "uart", "address"))
+    t->address = atoi(pct_get(p, "uart", "address"));
+}
+
+int main(int argc, char **argv) {
+  struct sigaction sa = {.sa_handler = request_shutdown};
+  sigemptyset(&sa.sa_mask);
+  sigaction(SIGINT, &sa, NULL);
+  sigaction(SIGTERM, &sa, NULL);
+  sigaction(SIGHUP, &sa, NULL);
+  setlocale(LC_ALL, "");
+  struct pct_ui_context ui = {.profiles_dir = "/etc/pelcodtui/cameras",
+      .state_path = "/etc/pelcodtui/state.conf", .message = "Ready",
+      .shutdown_signal = &shutdown_signal};
+  const char *profile = NULL;
+  bool dry = false, profile_from_state = false;
+  for (int i = 1; i < argc; i++) {
+    if (!strcmp(argv[i], "--profile") && i + 1 < argc) profile = argv[++i];
+    else if (!strcmp(argv[i], "--profiles-dir") && i + 1 < argc) ui.profiles_dir = argv[++i];
+    else if (!strcmp(argv[i], "--state") && i + 1 < argc) ui.state_path = argv[++i];
+    else if (!strcmp(argv[i], "--dry-run")) dry = true;
+    else if (!strcmp(argv[i], "--validate") && i + 1 < argc) {
+      struct pct_profile p; char error[160];
+      int result = pct_profile_load(&p, argv[++i], error, sizeof(error));
+      puts(result ? error : "profile valid");
+      return result != 0;
+    } else {
+      fprintf(stderr, "Usage: pelcodtui [--profile FILE] [--profiles-dir DIR] "
+                      "[--state FILE] [--dry-run] [--validate FILE]\n");
+      return 2;
+    }
+  }
+  initscr(); cbreak(); noecho(); keypad(stdscr, TRUE);
+  char picked[256], error[200];
+  struct pct_state_record saved;
+  if (!profile && !pct_state_read(ui.state_path, "app", "selection", &saved) &&
+      strcmp(saved.value, "generic")) {
+    profile = saved.value;
+    profile_from_state = true;
+  }
+  for (;;) {
+    bool generic = false;
+    if (!profile) {
+      int result = pct_ui_picker(&ui, picked, sizeof(picked));
+      if (result < 0) { endwin(); return 0; }
+      generic = result > 0;
+      if (!generic) profile = picked;
+      profile_from_state = false;
+      char state_error[128];
+      pct_state_write(ui.state_path, "app", "selection",
+                      generic ? "generic" : profile, "select", state_error,
+                      sizeof(state_error));
+    }
+    if (generic || !strcmp(profile, "generic")) {
+      int result = generic_tui(&ui, dry);
+      if (result == 2) { profile = NULL; continue; }
+      endwin(); return result;
+    }
+    struct pct_profile p;
+    if (pct_profile_load(&p, profile, error, sizeof(error))) {
+      if (profile_from_state) {
+        char state_error[128];
+        pct_state_remove(ui.state_path, "app", "selection", state_error,
+                         sizeof(state_error));
+        profile = NULL;
+        profile_from_state = false;
+        continue;
+      }
+      endwin(); fprintf(stderr, "%s\n", error); return 1;
+    }
+    struct pct_transport t;
+    configure_transport(&t, &p, dry);
+    int result = pct_ui_run(&ui, &p, &t);
+    if (result == 2) { profile = NULL; continue; }
+    endwin(); return result;
+  }
+}

--- a/pelcodtui/src/pelco.c
+++ b/pelcodtui/src/pelco.c
@@ -1,0 +1,381 @@
+#include "pelcodtui.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+#define PCT_LOCK_DIR "/tmp/btzoom.lock"
+#define PCT_STALE_LOCK_SECONDS 60
+
+void pct_sleep_ms(unsigned ms) {
+  struct timespec delay = {ms / 1000, (long)(ms % 1000) * 1000000L};
+  while (nanosleep(&delay, &delay) && errno == EINTR)
+    ;
+}
+
+static void frame(uint8_t address, uint8_t command1, uint8_t command2,
+                  uint8_t data1, uint8_t data2, uint8_t out[7]) {
+  out[0] = 0xff;
+  out[1] = address;
+  out[2] = command1;
+  out[3] = command2;
+  out[4] = data1;
+  out[5] = data2;
+  out[6] = (uint8_t)(address + command1 + command2 + data1 + data2);
+}
+
+void pct_frame_preset(uint8_t address, const char *op, unsigned preset,
+                      uint8_t out[7]) {
+  uint8_t command2 = !strcmp(op, "set") ? 3 : !strcmp(op, "clear") ? 5 : 7;
+  frame(address, 0, command2, 0, (uint8_t)preset, out);
+}
+
+void pct_frame_stop(uint8_t address, uint8_t out[7]) {
+  frame(address, 0, 0, 0, 0, out);
+}
+
+void pct_frame_motion(uint8_t address, const char *verb, unsigned speed,
+                      uint8_t out[7]) {
+  uint8_t command1 = 0, command2 = 0, data1 = 0, data2 = 0;
+
+  if (!strcmp(verb, "left")) {
+    command2 = 0x04;
+    data1 = (uint8_t)speed;
+  } else if (!strcmp(verb, "right")) {
+    command2 = 0x02;
+    data1 = (uint8_t)speed;
+  } else if (!strcmp(verb, "up")) {
+    command2 = 0x08;
+    data2 = (uint8_t)speed;
+  } else if (!strcmp(verb, "down")) {
+    command2 = 0x10;
+    data2 = (uint8_t)speed;
+  } else if (!strcmp(verb, "tele")) {
+    command2 = 0x20;
+  } else if (!strcmp(verb, "wide")) {
+    command2 = 0x40;
+  } else if (!strcmp(verb, "near")) {
+    command1 = 0x01;
+  } else if (!strcmp(verb, "far")) {
+    command2 = 0x80;
+  }
+
+  frame(address, command1, command2, data1, data2, out);
+}
+
+static speed_t baud_value(unsigned baud) {
+  switch (baud) {
+  case 1200:
+    return B1200;
+  case 2400:
+    return B2400;
+  case 4800:
+    return B4800;
+  case 9600:
+    return B9600;
+  case 19200:
+    return B19200;
+  case 38400:
+    return B38400;
+  case 57600:
+    return B57600;
+  case 115200:
+    return B115200;
+  default:
+    return 0;
+  }
+}
+
+static int lock_port(void) {
+  for (int i = 0; i < 40; i++) {
+    if (!mkdir(PCT_LOCK_DIR, 0700))
+      return 0;
+    if (errno != EEXIST)
+      return -1;
+
+    /* btzoom shares this lock and requires the directory to remain empty. */
+    struct stat status;
+    time_t now = time(NULL);
+    if (!stat(PCT_LOCK_DIR, &status) && now != (time_t)-1 &&
+        now - status.st_mtime > PCT_STALE_LOCK_SECONDS &&
+        !rmdir(PCT_LOCK_DIR))
+      continue;
+    pct_sleep_ms(50);
+  }
+  errno = EBUSY;
+  return -1;
+}
+
+static void unlock_port(void) { rmdir(PCT_LOCK_DIR); }
+
+static int open_uart(const struct pct_transport *transport, int *fd,
+                     char *summary, size_t n) {
+  *fd = -1;
+  speed_t speed = baud_value(transport->baud);
+  if (!speed) {
+    snprintf(summary, n, "unsupported baud");
+    return -1;
+  }
+  if (transport->dry_run)
+    return 0;
+
+  *fd = open(transport->device, O_WRONLY | O_NOCTTY);
+  if (*fd < 0) {
+    snprintf(summary, n, "open %s: %s", transport->device, strerror(errno));
+    return -1;
+  }
+
+  struct termios settings;
+  if (tcgetattr(*fd, &settings)) {
+    snprintf(summary, n, "termios: %s", strerror(errno));
+    goto fail;
+  }
+  cfmakeraw(&settings);
+  cfsetispeed(&settings, speed);
+  cfsetospeed(&settings, speed);
+  settings.c_cflag &= ~(PARENB | CSTOPB | CSIZE);
+  settings.c_cflag |= CLOCAL | CREAD;
+  settings.c_cflag |= CS8;
+#ifdef CRTSCTS
+  settings.c_cflag &= ~CRTSCTS;
+#endif
+  if (tcsetattr(*fd, TCSANOW, &settings)) {
+    snprintf(summary, n, "termios: %s", strerror(errno));
+    goto fail;
+  }
+  return 0;
+
+fail:
+  close(*fd);
+  *fd = -1;
+  return -1;
+}
+
+static int write_frame(int fd, const uint8_t frame_bytes[7]) {
+  size_t written = 0;
+  while (written < 7) {
+    ssize_t result = write(fd, frame_bytes + written, 7 - written);
+    if (result < 0 && errno == EINTR)
+      continue;
+    if (result <= 0)
+      return -1;
+    written += (size_t)result;
+  }
+  return tcdrain(fd);
+}
+
+int pct_parse_command(const char *text, bool allow_value,
+                      struct pct_command *command) {
+  char op[32], argument[32], extra;
+  int fields = sscanf(text ? text : "", " %31s %31s %c", op, argument, &extra);
+
+  memset(command, 0, sizeof(*command));
+  if (fields == 1 && !strcmp(op, "stop")) {
+    command->op = PCT_COMMAND_STOP;
+    return 0;
+  }
+  if (fields != 2)
+    return -1;
+
+  if (!strcmp(op, "preset_set"))
+    command->op = PCT_COMMAND_PRESET_SET;
+  else if (!strcmp(op, "preset_call"))
+    command->op = PCT_COMMAND_PRESET_CALL;
+  else if (!strcmp(op, "preset_clear"))
+    command->op = PCT_COMMAND_PRESET_CLEAR;
+  else
+    return -1;
+
+  if (allow_value && !strcmp(argument, "$value")) {
+    command->value_placeholder = true;
+    return 0;
+  }
+
+  char *end = NULL;
+  errno = 0;
+  unsigned long value = strtoul(argument, &end, 10);
+  if (errno || !end || *end || value < 1 || value > 255)
+    return -1;
+  command->value = (unsigned)value;
+  return 0;
+}
+
+static const char *preset_op(enum pct_command_op op) {
+  if (op == PCT_COMMAND_PRESET_SET)
+    return "set";
+  if (op == PCT_COMMAND_PRESET_CLEAR)
+    return "clear";
+  return "call";
+}
+
+int pct_execute(const struct pct_transport *transport, const char *sequence,
+                char *summary, size_t n) {
+  bool locked = false;
+  if (!transport->dry_run && lock_port()) {
+    snprintf(summary, n, "PTZ port busy: %s", strerror(errno));
+    return -1;
+  }
+  locked = !transport->dry_run;
+
+  int fd = -1, result = -1, frames = 0;
+  if (open_uart(transport, &fd, summary, n))
+    goto done;
+
+  char buffer[PCT_TEXT];
+  snprintf(buffer, sizeof(buffer), "%s", sequence);
+  char *save = NULL;
+  bool parsed = false;
+  for (char *part = strtok_r(buffer, ";", &save); part;
+       part = strtok_r(NULL, ";", &save)) {
+    parsed = true;
+    struct pct_command command;
+    uint8_t frame_bytes[7];
+    if (pct_parse_command(part, false, &command)) {
+      snprintf(summary, n, "invalid command: %s", part);
+      goto done;
+    }
+
+    if (command.op == PCT_COMMAND_STOP) {
+      for (unsigned i = 0; i < transport->stop_repeat; i++) {
+        pct_frame_stop(transport->address, frame_bytes);
+        if (!transport->dry_run && write_frame(fd, frame_bytes))
+          goto io_error;
+        frames++;
+        if (i + 1 < transport->stop_repeat)
+          pct_sleep_ms(transport->stop_delay_ms);
+      }
+    } else {
+      pct_frame_preset(transport->address, preset_op(command.op), command.value,
+                       frame_bytes);
+      if (!transport->dry_run && write_frame(fd, frame_bytes))
+        goto io_error;
+      frames++;
+    }
+    if (save && *save)
+      pct_sleep_ms(transport->sequence_delay_ms);
+  }
+  if (!parsed) {
+    snprintf(summary, n, "invalid empty command sequence");
+    goto done;
+  }
+
+  snprintf(summary, n, "sent %d frame%s%s", frames, frames == 1 ? "" : "s",
+           transport->dry_run ? " (dry run)" : "");
+  result = 0;
+  goto done;
+
+io_error:
+  snprintf(summary, n, "UART write failed: %s", strerror(errno));
+done:
+  if (fd >= 0)
+    close(fd);
+  if (locked)
+    unlock_port();
+  return result;
+}
+
+int pct_motion_start(struct pct_motion *motion,
+                     const struct pct_transport *transport, const char *verb,
+                     unsigned speed, char *summary, size_t n) {
+  if (motion->active) {
+    snprintf(summary, n, "motion already active");
+    return -1;
+  }
+  if (!transport->dry_run && lock_port()) {
+    snprintf(summary, n, "PTZ port busy");
+    return -1;
+  }
+
+  motion->transport = transport;
+  if (open_uart(transport, &motion->fd, summary, n))
+    goto fail;
+
+  uint8_t frame_bytes[7];
+  pct_frame_motion(transport->address, verb, speed, frame_bytes);
+  if (!transport->dry_run && write_frame(motion->fd, frame_bytes)) {
+    snprintf(summary, n, "UART write failed: %s", strerror(errno));
+    goto fail;
+  }
+  motion->active = true;
+  snprintf(summary, n, "%s active%s", verb,
+           transport->dry_run ? " (dry run)" : "");
+  return 0;
+
+fail:
+  if (motion->fd >= 0)
+    close(motion->fd);
+  motion->fd = -1;
+  motion->transport = NULL;
+  if (!transport->dry_run)
+    unlock_port();
+  return -1;
+}
+
+int pct_motion_stop(struct pct_motion *motion, char *summary, size_t n) {
+  if (!motion->active)
+    return 0;
+
+  const struct pct_transport *transport = motion->transport;
+  uint8_t frame_bytes[7];
+  unsigned sent = 0;
+  char last_error[128] = "UART STOP failed";
+  for (unsigned i = 0; i < transport->stop_repeat; i++) {
+    if (motion->fd < 0 &&
+        open_uart(transport, &motion->fd, last_error, sizeof(last_error))) {
+      if (i + 1 < transport->stop_repeat)
+        pct_sleep_ms(transport->stop_delay_ms);
+      continue;
+    }
+    pct_frame_stop(transport->address, frame_bytes);
+    if (!transport->dry_run && write_frame(motion->fd, frame_bytes)) {
+      snprintf(last_error, sizeof(last_error), "UART STOP failed: %s",
+               strerror(errno));
+      close(motion->fd);
+      motion->fd = -1;
+    } else
+      sent++;
+    if (i + 1 < transport->stop_repeat)
+      pct_sleep_ms(transport->stop_delay_ms);
+  }
+
+  if (motion->fd >= 0)
+    close(motion->fd);
+  motion->fd = -1;
+  if (!sent) {
+    snprintf(summary, n, "%s", last_error);
+    return -1;
+  }
+  motion->active = false;
+  motion->transport = NULL;
+  if (!transport->dry_run)
+    unlock_port();
+  if (sent == transport->stop_repeat)
+    snprintf(summary, n, "stopped");
+  else
+    snprintf(summary, n, "stopped (%u/%u STOP frames)", sent,
+             transport->stop_repeat);
+  return 0;
+}
+
+int pct_move(const struct pct_transport *transport, const char *verb,
+             unsigned speed, unsigned duration, char *summary, size_t n) {
+  if (!strcmp(verb, "stop"))
+    return pct_execute(transport, "stop", summary, n);
+
+  struct pct_motion motion = {.fd = -1};
+  if (pct_motion_start(&motion, transport, verb, speed, summary, n))
+    return -1;
+  pct_sleep_ms(duration);
+  if (pct_motion_stop(&motion, summary, n))
+    return -1;
+  snprintf(summary, n, "%s %ums%s", verb, duration,
+           transport->dry_run ? " (dry run)" : "");
+  return 0;
+}

--- a/pelcodtui/src/pelcodtui.h
+++ b/pelcodtui/src/pelcodtui.h
@@ -1,0 +1,79 @@
+#ifndef PELCODTUI_H
+#define PELCODTUI_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define PCT_MAX_ENTRIES 512
+#define PCT_MAX_SECTIONS 96
+#define PCT_TEXT 512
+
+struct pct_entry { char section[96], key[96], value[PCT_TEXT]; };
+struct pct_profile {
+    struct pct_entry entries[PCT_MAX_ENTRIES];
+    char sections[PCT_MAX_SECTIONS][96];
+    size_t count, section_count;
+    char path[256];
+};
+
+struct pct_transport {
+    char device[128];
+    unsigned baud, address, sequence_delay_ms;
+    unsigned stop_repeat, stop_delay_ms;
+    bool dry_run;
+};
+
+struct pct_motion {
+    const struct pct_transport *transport;
+    int fd;
+    bool active;
+};
+
+struct pct_state_record {
+    char value[128], command[PCT_TEXT], timestamp[40];
+};
+
+enum pct_command_op {
+    PCT_COMMAND_STOP,
+    PCT_COMMAND_PRESET_SET,
+    PCT_COMMAND_PRESET_CALL,
+    PCT_COMMAND_PRESET_CLEAR,
+};
+
+struct pct_command {
+    enum pct_command_op op;
+    unsigned value;
+    bool value_placeholder;
+};
+
+int pct_profile_load(struct pct_profile *p, const char *path, char *err, size_t n);
+int pct_profile_validate(const struct pct_profile *p, char *err, size_t n);
+const char *pct_get(const struct pct_profile *p, const char *section, const char *key);
+bool pct_csv_has(const char *csv, const char *value);
+int pct_parse_command(const char *text, bool allow_value,
+                      struct pct_command *command);
+int pct_expand_setting(const struct pct_profile *p, const char *id, const char *value,
+                       char *out, size_t n, char *err, size_t en);
+
+void pct_frame_preset(uint8_t addr, const char *op, unsigned preset, uint8_t out[7]);
+void pct_frame_stop(uint8_t addr, uint8_t out[7]);
+void pct_frame_motion(uint8_t addr, const char *verb, unsigned speed, uint8_t out[7]);
+int pct_execute(const struct pct_transport *t, const char *sequence,
+                char *summary, size_t n);
+int pct_move(const struct pct_transport *t, const char *verb, unsigned speed,
+             unsigned duration_ms, char *summary, size_t n);
+int pct_motion_start(struct pct_motion *motion, const struct pct_transport *t,
+                     const char *verb, unsigned speed, char *summary, size_t n);
+int pct_motion_stop(struct pct_motion *motion, char *summary, size_t n);
+
+int pct_state_read(const char *path, const char *profile, const char *setting,
+                   struct pct_state_record *out);
+int pct_state_write(const char *path, const char *profile, const char *setting,
+                    const char *value, const char *command, char *err, size_t n);
+int pct_state_remove(const char *path, const char *profile, const char *setting,
+                     char *err, size_t n);
+
+void pct_sleep_ms(unsigned ms);
+
+#endif

--- a/pelcodtui/src/profile.c
+++ b/pelcodtui/src/profile.c
@@ -1,0 +1,159 @@
+#include "pelcodtui.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char *trim(char *s) {
+    while (*s && isspace((unsigned char)*s)) s++;
+    char *e = s + strlen(s);
+    while (e > s && isspace((unsigned char)e[-1])) --e;
+    *e = 0;
+    return s;
+}
+
+static int add(struct pct_profile *p, const char *sec, const char *key, const char *val) {
+    if (p->count >= PCT_MAX_ENTRIES) return -1;
+    snprintf(p->entries[p->count].section, 96, "%s", sec);
+    snprintf(p->entries[p->count].key, 96, "%s", key);
+    snprintf(p->entries[p->count].value, PCT_TEXT, "%s", val);
+    p->count++;
+    return 0;
+}
+
+const char *pct_get(const struct pct_profile *p, const char *section, const char *key) {
+    for (size_t i = 0; i < p->count; i++)
+        if (!strcmp(p->entries[i].section, section) && !strcmp(p->entries[i].key, key))
+            return p->entries[i].value;
+    return NULL;
+}
+
+bool pct_csv_has(const char *csv, const char *value) {
+    if (!csv || !value) return false;
+    char buf[PCT_TEXT]; snprintf(buf, sizeof(buf), "%s", csv);
+    char *save = NULL;
+    for (char *s = strtok_r(buf, ",", &save); s; s = strtok_r(NULL, ",", &save))
+        if (!strcmp(trim(s), value)) return true;
+    return false;
+}
+
+int pct_profile_load(struct pct_profile *p, const char *path, char *err, size_t n) {
+    memset(p, 0, sizeof(*p));
+    FILE *f = fopen(path, "r");
+    if (!f) { snprintf(err, n, "open %s: %s", path, strerror(errno)); return -1; }
+    snprintf(p->path, sizeof(p->path), "%s", path);
+    char line[1024], sec[96] = "";
+    while (fgets(line, sizeof(line), f)) {
+        char *s = trim(line), *hash;
+        if (!*s || *s == '#') continue;
+        if ((hash = strchr(s, '#'))) *hash = 0;
+        s = trim(s); if (!*s) continue;
+        if (*s == '[') {
+            char *e = strchr(s, ']');
+            if (!e) { snprintf(err, n, "invalid section"); fclose(f); return -1; }
+            *e = 0; snprintf(sec, sizeof(sec), "%s", s + 1);
+            bool seen = false;
+            for (size_t i=0;i<p->section_count;i++) if (!strcmp(p->sections[i],sec)) seen=true;
+            if (!seen && p->section_count < PCT_MAX_SECTIONS)
+                snprintf(p->sections[p->section_count++], 96, "%s", sec);
+            continue;
+        }
+        char *eq = strchr(s, '=');
+        if (!eq || !*sec) { snprintf(err, n, "key outside section"); fclose(f); return -1; }
+        *eq = 0;
+        if (add(p, sec, trim(s), trim(eq+1))) { snprintf(err,n,"profile too large"); fclose(f); return -1; }
+    }
+    fclose(f);
+    return pct_profile_validate(p, err, n);
+}
+
+static bool uint_in(const char *s, unsigned lo, unsigned hi) {
+    if (!s || !*s) return false;
+    char *e; unsigned long v = strtoul(s, &e, 10);
+    return *e == 0 && v >= lo && v <= hi;
+}
+
+static bool baud_valid(const char *s) {
+    static const char *values[] = {"1200","2400","4800","9600","19200","38400","57600","115200"};
+    if (!s) return false;
+    for (size_t i=0;i<sizeof(values)/sizeof(values[0]);i++) if(!strcmp(s,values[i])) return true;
+    return false;
+}
+
+static bool command_valid(const char *cmd, bool allow_value) {
+    if (!cmd || !*cmd) return false;
+    char buf[PCT_TEXT]; snprintf(buf,sizeof(buf),"%s",cmd);
+    char *save=NULL;
+    bool parsed=false;
+    for(char *part=strtok_r(buf,";",&save);part;part=strtok_r(NULL,";",&save)) {
+        parsed=true;
+        struct pct_command command;
+        if (pct_parse_command(trim(part), allow_value, &command)) return false;
+    }
+    return parsed;
+}
+
+int pct_profile_validate(const struct pct_profile *p, char *err, size_t n) {
+    if (!pct_get(p,"profile","id") || strcmp(pct_get(p,"profile","schema_version") ?: "","1")) {
+        snprintf(err,n,"profile requires schema_version=1 and id"); return -1;
+    }
+    const char *baud=pct_get(p,"uart","baud"),*address=pct_get(p,"uart","address");
+    if(baud&&!baud_valid(baud)){snprintf(err,n,"uart invalid baud");return -1;}
+    if(address&&!uint_in(address,1,255)){snprintf(err,n,"uart address must be 1..255");return -1;}
+    for (size_t i=0;i<p->section_count;i++) {
+        const char *s=p->sections[i];
+        if (!strncmp(s,"menu.",5)) {
+            const char *items=pct_get(p,s,"items");
+            if(!items){snprintf(err,n,"%s missing items",s);return -1;}
+            char b[PCT_TEXT];snprintf(b,sizeof(b),"%s",items);char *sv=NULL;
+            for(char *id=strtok_r(b,",",&sv);id;id=strtok_r(NULL,",",&sv)){
+                id=trim(id);char setting[128],action[128];snprintf(setting,sizeof(setting),"setting.%s",id);snprintf(action,sizeof(action),"action.%s",id);
+                if(strcmp(id,"__preset_control")&&strcmp(id,"__tui_settings")&&!pct_get(p,setting,"label")&&!pct_get(p,action,"label")){snprintf(err,n,"%s unknown item %s",s,id);return -1;}
+            }
+        } else if (!strncmp(s,"setting.",8)) {
+            const char *type=pct_get(p,s,"type"), *label=pct_get(p,s,"label"), *desc=pct_get(p,s,"description");
+            if(!type||!label||!desc){snprintf(err,n,"%s missing metadata",s);return -1;}
+            if(!strcmp(type,"number")) {
+                const char *lo=pct_get(p,s,"min"),*hi=pct_get(p,s,"max"),*cmd=pct_get(p,s,"command");
+                if(!uint_in(lo,0,255)||!uint_in(hi,1,255)||atoi(lo)>atoi(hi)||!command_valid(cmd,true)) {snprintf(err,n,"%s invalid number",s);return -1;}
+            } else if(!strcmp(type,"choice")||!strcmp(type,"toggle")) {
+                const char *opts=pct_get(p,s,"options"); if(!opts){snprintf(err,n,"%s missing options",s);return -1;}
+                char b[PCT_TEXT];snprintf(b,sizeof(b),"%s",opts);char *sv=NULL;
+                for(char *o=strtok_r(b,",",&sv);o;o=strtok_r(NULL,",",&sv)) {char k[160];snprintf(k,sizeof(k),"option.%s.command",trim(o));if(!command_valid(pct_get(p,s,k),false)){snprintf(err,n,"%s invalid option",s);return -1;}}
+            } else {snprintf(err,n,"%s invalid type",s);return -1;}
+        } else if (!strncmp(s,"action.",7) && !command_valid(pct_get(p,s,"command"),false)) {
+            snprintf(err,n,"%s invalid action",s);return -1;
+        }
+    }
+    return 0;
+}
+
+int pct_expand_setting(const struct pct_profile *p, const char *id, const char *value,
+                       char *out, size_t n, char *err, size_t en) {
+    char sec[128]; snprintf(sec,sizeof(sec),"setting.%s",id);
+    const char *type=pct_get(p,sec,"type"), *cmd=NULL;
+    if(!type){snprintf(err,en,"unknown setting");return -1;}
+    if(!strcmp(type,"number")) {
+        unsigned lo=atoi(pct_get(p,sec,"min")),hi=atoi(pct_get(p,sec,"max"));
+        if(!uint_in(value,lo,hi)){snprintf(err,en,"value must be %u..%u",lo,hi);return -1;}
+        cmd=pct_get(p,sec,"command");
+    } else {
+        if(!pct_csv_has(pct_get(p,sec,"options"),value)){snprintf(err,en,"invalid option");return -1;}
+        char key[160];snprintf(key,sizeof(key),"option.%s.command",value);cmd=pct_get(p,sec,key);
+    }
+    const char *needle="$value", *q;
+    size_t used=0,needle_len=strlen(needle),value_len=strlen(value);
+    if(!n){snprintf(err,en,"expanded command too long");return -1;}
+    while((q=strstr(cmd,needle))){
+        size_t prefix=(size_t)(q-cmd);
+        if(prefix+value_len>=n-used){snprintf(err,en,"expanded command too long");return -1;}
+        memcpy(out+used,cmd,prefix);used+=prefix;
+        memcpy(out+used,value,value_len);used+=value_len;
+        cmd=q+needle_len;
+    }
+    size_t tail=strlen(cmd);
+    if(tail>=n-used){snprintf(err,en,"expanded command too long");return -1;}
+    memcpy(out+used,cmd,tail+1);return 0;
+}

--- a/pelcodtui/src/state.c
+++ b/pelcodtui/src/state.c
@@ -1,0 +1,57 @@
+#include "pelcodtui.h"
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static void section_name(char *out,size_t n,const char *p,const char *s){snprintf(out,n,"[%s.%s]",p,s);}
+static void copy_value(char *out,size_t n,const char *value){if(!n)return;size_t len=strlen(value);if(len>=n)len=n-1;memcpy(out,value,len);out[len]=0;}
+int pct_state_read(const char *path,const char *profile,const char *setting,struct pct_state_record *out){
+    memset(out,0,sizeof(*out));FILE*f=fopen(path,"r");if(!f)return-1;char target[200],line[1024];section_name(target,sizeof(target),profile,setting);bool in=false;
+    while(fgets(line,sizeof(line),f)){line[strcspn(line,"\r\n")]=0;if(line[0]=='[')in=!strcmp(line,target);else if(in){if(!strncmp(line,"value=",6))copy_value(out->value,sizeof(out->value),line+6);else if(!strncmp(line,"command=",8))copy_value(out->command,sizeof(out->command),line+8);else if(!strncmp(line,"timestamp=",10))copy_value(out->timestamp,sizeof(out->timestamp),line+10);}}
+    fclose(f);return out->timestamp[0]?0:-1;
+}
+int pct_state_write(const char *path,const char *profile,const char *setting,const char *value,const char *command,char *err,size_t n){
+    char tmp[300];snprintf(tmp,sizeof(tmp),"%s.tmp",path);FILE*out=fopen(tmp,"w");if(!out){snprintf(err,n,"state: %s",strerror(errno));return-1;}FILE*in=fopen(path,"r");char target[200],line[1024];section_name(target,sizeof(target),profile,setting);bool skip=false;
+    if(in){while(fgets(line,sizeof(line),in)){if(line[0]=='[')skip=!strncmp(line,target,strlen(target))&&(line[strlen(target)]=='\n'||line[strlen(target)]=='\r'||line[strlen(target)]==0);if(!skip)fputs(line,out);}fclose(in);}
+    time_t now=time(NULL);struct tm tm;localtime_r(&now,&tm);char stamp[40];strftime(stamp,sizeof(stamp),"%Y-%m-%d %H:%M:%S %z",&tm);
+    fprintf(out,"\n%s\nvalue=%s\ncommand=%s\ntimestamp=%s\n",target,value,command,stamp);fflush(out);fsync(fileno(out));if(fclose(out)||rename(tmp,path)){snprintf(err,n,"state save: %s",strerror(errno));unlink(tmp);return-1;}return 0;
+}
+
+int pct_state_remove(const char *path, const char *profile, const char *setting,
+                     char *err, size_t n) {
+    char tmp[300], target[200], line[1024];
+    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+    FILE *in = fopen(path, "r");
+    if (!in) {
+        if (errno == ENOENT) return 0;
+        snprintf(err, n, "state: %s", strerror(errno));
+        return -1;
+    }
+    FILE *out = fopen(tmp, "w");
+    if (!out) {
+        snprintf(err, n, "state: %s", strerror(errno));
+        fclose(in);
+        return -1;
+    }
+    section_name(target, sizeof(target), profile, setting);
+    bool skip = false;
+    while (fgets(line, sizeof(line), in)) {
+        if (line[0] == '[')
+            skip = !strncmp(line, target, strlen(target)) &&
+                   (line[strlen(target)] == '\n' ||
+                    line[strlen(target)] == '\r' ||
+                    line[strlen(target)] == 0);
+        if (!skip) fputs(line, out);
+    }
+    fclose(in);
+    fflush(out);
+    fsync(fileno(out));
+    if (fclose(out) || rename(tmp, path)) {
+        snprintf(err, n, "state save: %s", strerror(errno));
+        unlink(tmp);
+        return -1;
+    }
+    return 0;
+}

--- a/pelcodtui/src/tui.c
+++ b/pelcodtui/src/tui.c
@@ -1,0 +1,202 @@
+#include "tui_internal.h"
+#include <curses.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+static int64_t monotonic_ms(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+static const char *motion_key(int c, const struct pct_tui_settings *s,
+                              unsigned *speed, unsigned *pulse) {
+  *speed = 30;
+  *pulse = s->pan_pulse;
+  if (c == 'a' || c == 'A')
+    return "left";
+  if (c == 'd' || c == 'D')
+    return "right";
+  if (c == 'w' || c == 'W')
+    return "up";
+  if (c == 's' || c == 'S')
+    return "down";
+  *speed = 0;
+  if (c == 'z' || c == 'Z') {
+    *pulse = s->zoom_pulse;
+    return "wide";
+  }
+  if (c == 'x' || c == 'X') {
+    *pulse = s->zoom_pulse;
+    return "tele";
+  }
+  if (c == 'n' || c == 'N') {
+    *pulse = s->focus_pulse;
+    return "near";
+  }
+  if (c == 'f' || c == 'F') {
+    *pulse = s->focus_pulse;
+    return "far";
+  }
+  return NULL;
+}
+static int stop_motion(struct pct_ui_context *ui, struct pct_motion *m) {
+  return m->active ? pct_motion_stop(m, ui->message, sizeof(ui->message)) : 0;
+}
+void pct_ui_draw_areas(int split) {
+  int bottom = LINES - 6;
+  mvhline(2, 1, ACS_HLINE, COLS - 2);
+  mvhline(bottom, 1, ACS_HLINE, COLS - 2);
+  mvhline(LINES - 3, 1, ACS_HLINE, COLS - 2);
+  mvhline(LINES - 1, 1, ACS_HLINE, COLS - 2);
+  mvvline(3, 1, ACS_VLINE, LINES - 4);
+  mvvline(3, COLS - 2, ACS_VLINE, LINES - 4);
+  mvvline(3, split - 1, ACS_VLINE, bottom - 3);
+  mvaddch(2, 1, ACS_ULCORNER);
+  mvaddch(2, COLS - 2, ACS_URCORNER);
+  mvaddch(bottom, 1, ACS_LTEE);
+  mvaddch(bottom, COLS - 2, ACS_RTEE);
+  mvaddch(LINES - 3, 1, ACS_LTEE);
+  mvaddch(LINES - 3, COLS - 2, ACS_RTEE);
+  mvaddch(LINES - 1, 1, ACS_LLCORNER);
+  mvaddch(LINES - 1, COLS - 2, ACS_LRCORNER);
+  mvaddch(2, split - 1, ACS_TTEE);
+  mvaddch(bottom, split - 1, ACS_BTEE);
+  mvprintw(2, 3, " Settings ");
+  mvprintw(2, split + 1, " Details ");
+  mvprintw(bottom, 3, " Status ");
+  mvprintw(LINES - 3, 3, " Controls ");
+}
+
+int pct_ui_run(struct pct_ui_context *ui, struct pct_profile *p,
+               struct pct_transport *t) {
+  int sel = 0;
+  const char *main_labels[] = {"Preset control", "Camera settings",
+                               "TUI settings"};
+  const char *main_descriptions[] = {
+      "Set or call any Pelco-D preset from 1 through 255.",
+      "Configure camera controller features grouped by function.",
+      "Configure keyboard movement pulse durations."};
+  struct pct_motion motion = {.fd = -1};
+  struct pct_tui_settings settings;
+  pct_ui_load_settings(ui, &settings);
+  char active[16] = "";
+  int64_t deadline = 0, started = 0, stop_retry_at = 0;
+  keypad(stdscr, TRUE);
+  timeout(20);
+  curs_set(0);
+  if (has_colors()) {
+    start_color();
+    use_default_colors();
+    init_pair(1, COLOR_CYAN, -1);
+    init_pair(2, COLOR_YELLOW, -1);
+  }
+  for (;;) {
+    if (pct_ui_shutdown(ui)) {
+      for (int tries = 0; motion.active && tries < 3; tries++) {
+        stop_motion(ui, &motion);
+        pct_sleep_ms(20);
+      }
+      return 128 + *ui->shutdown_signal;
+    }
+    int64_t now = monotonic_ms();
+    if (motion.active && now >= deadline && now >= stop_retry_at) {
+      if (stop_motion(ui, &motion))
+        stop_retry_at = now + 250;
+      else
+        active[0] = 0;
+    }
+    if (motion.active && now < deadline)
+      snprintf(ui->message, sizeof(ui->message), "%s active (%lld/%lld ms)", active,
+               (long long)(now - started), (long long)(deadline - started));
+    erase();
+    attron(COLOR_PAIR(1) | A_BOLD);
+    mvprintw(0, 2, "pelcodtui");
+    attroff(COLOR_PAIR(1) | A_BOLD);
+    printw("  %s  %s @ %u addr %u%s",
+           pct_ui_nz(pct_get(p, "profile", "name"), "Unnamed profile"),
+           t->device, t->baud, t->address, t->dry_run ? "  DRY RUN" : "");
+    mvprintw(
+        1, 2,
+        "Camera state is not readable; values below are last commands sent.");
+    int listw = COLS / 2;
+    if (listw < 38)
+      listw = 38;
+    pct_ui_draw_areas(listw);
+    for (int i = 0; i < 3; i++) {
+      if (i == sel)
+        attron(A_REVERSE);
+      mvprintw(3 + i, 2, "%-*.*s", listw - 4, listw - 4, main_labels[i]);
+      if (i == sel)
+        attroff(A_REVERSE);
+    }
+    int details_x = listw + 1;
+    attron(COLOR_PAIR(1));
+    mvprintw(3, details_x, "Main menu");
+    attroff(COLOR_PAIR(1));
+    mvprintw(4, details_x, "%s", main_labels[sel]);
+    mvprintw(6, details_x, "%.*s", COLS - details_x - 2,
+             main_descriptions[sel]);
+    if (sel == 2) {
+      mvprintw(9, details_x, "Pan/tilt: %u ms", settings.pan_pulse);
+      mvprintw(10, details_x, "Zoom: %u ms", settings.zoom_pulse);
+      mvprintw(11, details_x, "Focus: %u ms", settings.focus_pulse);
+    }
+    attron(COLOR_PAIR(2));
+    mvprintw(LINES - 4, 2, "%.*s", COLS - 4, ui->message);
+    attroff(COLOR_PAIR(2));
+    mvprintw(LINES - 2, 2,
+             "Enter select  C camera  WASD move  Z/X zoom  N/F "
+             "focus  Space STOP  Q quit");
+    refresh();
+    int c = getch();
+    if (c == ERR)
+      continue;
+    unsigned speed, pulse;
+    const char *v = motion_key(c, &settings, &speed, &pulse);
+    if (v) {
+      now = monotonic_ms();
+      if (motion.active && !strcmp(active, v)) {
+        deadline += pulse;
+        int64_t cap = started + 5000;
+        if (deadline > cap)
+          deadline = cap;
+      } else {
+        stop_motion(ui, &motion);
+        if (!motion.active && !pct_motion_start(&motion, t, v, speed,
+                                                ui->message, sizeof(ui->message))) {
+          snprintf(active, sizeof(active), "%s", v);
+          started = now;
+          deadline = now + pulse;
+          stop_retry_at = deadline;
+        }
+      }
+      continue;
+    }
+    stop_motion(ui, &motion);
+    if (motion.active)
+      continue;
+    active[0] = 0;
+    if (c == 'q' || c == 'Q')
+      break;
+    if (c == 'c' || c == 'C')
+      return 2;
+    if (c == KEY_UP && sel)
+      sel--;
+    else if (c == KEY_DOWN && sel < 2)
+      sel++;
+    else if (c == '\n') {
+      if (sel == 0) {
+        pct_ui_preset_menu(ui, t, false, p);
+        timeout(20);
+      } else if (sel == 1) {
+        pct_ui_camera_settings_menu(ui, p, t);
+      } else {
+        pct_ui_settings_menu(ui, &settings);
+      }
+    } else if (c == ' ')
+      pct_move(t, "stop", 0, 0, ui->message, sizeof(ui->message));
+  }
+  stop_motion(ui, &motion);
+  return 0;
+}

--- a/pelcodtui/src/tui_internal.h
+++ b/pelcodtui/src/tui_internal.h
@@ -1,0 +1,31 @@
+#ifndef PCT_TUI_INTERNAL_H
+#define PCT_TUI_INTERNAL_H
+
+#include "pelcodtui.h"
+#include <signal.h>
+
+struct pct_tui_settings { unsigned pan_pulse, zoom_pulse, focus_pulse; };
+struct pct_ui_context {
+  const char *profiles_dir, *state_path;
+  char message[256];
+  volatile sig_atomic_t *shutdown_signal;
+};
+
+static inline bool pct_ui_shutdown(const struct pct_ui_context *ui) {
+  return *ui->shutdown_signal != 0;
+}
+
+const char *pct_ui_nz(const char *value, const char *fallback);
+void pct_ui_draw_areas(int split);
+void pct_ui_load_settings(struct pct_ui_context *, struct pct_tui_settings *);
+int pct_ui_picker(struct pct_ui_context *, char *, size_t);
+int pct_ui_preset_menu(struct pct_ui_context *, const struct pct_transport *,
+                       bool, const struct pct_profile *);
+void pct_ui_camera_settings_menu(struct pct_ui_context *,
+                                 const struct pct_profile *,
+                                 const struct pct_transport *);
+void pct_ui_settings_menu(struct pct_ui_context *, struct pct_tui_settings *);
+int pct_ui_run(struct pct_ui_context *, struct pct_profile *,
+               struct pct_transport *);
+
+#endif

--- a/pelcodtui/src/tui_menus.c
+++ b/pelcodtui/src/tui_menus.c
@@ -1,0 +1,650 @@
+#include "tui_internal.h"
+#include <ctype.h>
+#include <curses.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#define MAX_ITEMS 96
+struct item {
+  char id[96], section[128], menu[64];
+  bool action, tui, preset;
+};
+static int confirm_dialog(struct pct_ui_context *ui, const char *text);
+const char *pct_ui_nz(const char *s, const char *d) { return s && *s ? s : d; }
+static void split_items(struct item *out, int *count, const char *menu,
+                        const char *csv, const struct pct_profile *p) {
+  char b[PCT_TEXT];
+  snprintf(b, sizeof(b), "%s", csv ?: "");
+  char *sv = NULL;
+  for (char *x = strtok_r(b, ",", &sv); x && *count < MAX_ITEMS;
+       x = strtok_r(NULL, ",", &sv)) {
+    while (*x == ' ')
+      x++;
+    struct item *i = &out[(*count)++];
+    memset(i, 0, sizeof(*i));
+    snprintf(i->id, sizeof(i->id), "%s", x);
+    snprintf(i->menu, sizeof(i->menu), "%s", menu);
+    if (!strcmp(x, "__preset_control")) {
+      snprintf(i->id, sizeof(i->id), "preset");
+      i->preset = true;
+      continue;
+    }
+    if (!strcmp(x, "__tui_settings")) {
+      snprintf(i->id, sizeof(i->id), "tui_settings");
+      i->tui = true;
+      i->action = true;
+      continue;
+    }
+    snprintf(i->section, sizeof(i->section), "setting.%s", x);
+    i->tui = false;
+    i->preset = false;
+    i->action = pct_get(p, i->section, "label") == NULL;
+    if (i->action)
+      snprintf(i->section, sizeof(i->section), "action.%s", x);
+  }
+}
+static int collect(const struct pct_profile *p, struct item *out) {
+  int n = 0;
+  for (size_t i = 0; i < p->section_count; i++)
+    if (!strncmp(p->sections[i], "menu.", 5)) {
+      const char *label =
+          pct_ui_nz(pct_get(p, p->sections[i], "label"), p->sections[i] + 5);
+      split_items(out, &n, label, pct_get(p, p->sections[i], "items"), p);
+    }
+  for (size_t s = 0; s < p->section_count && n < MAX_ITEMS; s++) {
+    const char *section = p->sections[s];
+    size_t prefix = !strncmp(section, "setting.", 8)  ? 8
+                    : !strncmp(section, "action.", 7) ? 7
+                                                      : 0;
+    if (!prefix)
+      continue;
+    const char *id = section + prefix;
+    bool listed = false;
+    for (int i = 0; i < n; i++)
+      if (!strcmp(out[i].id, id))
+        listed = true;
+    if (listed)
+      continue;
+    struct item *item = &out[n++];
+    memset(item, 0, sizeof(*item));
+    snprintf(item->id, sizeof(item->id), "%s", id);
+    snprintf(item->section, sizeof(item->section), "%s", section);
+    snprintf(item->menu, sizeof(item->menu), "Other / misc");
+    item->action = prefix == 7;
+  }
+  return n;
+}
+
+static unsigned saved_uint(struct pct_ui_context *ui, const char *key,
+                           unsigned fallback) {
+  struct pct_state_record r;
+  if (pct_state_read(ui->state_path, "app", key, &r))
+    return fallback;
+  char *end = NULL;
+  unsigned long v = strtoul(r.value, &end, 10);
+  return end && !*end && v > 0 && v <= 5000 ? (unsigned)v : fallback;
+}
+void pct_ui_load_settings(struct pct_ui_context *ui, struct pct_tui_settings *s) {
+  s->pan_pulse = saved_uint(ui, "pan_pulse", 250);
+  s->zoom_pulse = saved_uint(ui, "zoom_pulse", 300);
+  s->focus_pulse = saved_uint(ui, "focus_pulse", 120);
+}
+static const char *tui_label(const char *id) {
+  if (!strcmp(id, "tui_settings"))
+    return "TUI settings";
+  if (!strcmp(id, "pan_pulse"))
+    return "Pan/tilt key pulse";
+  if (!strcmp(id, "zoom_pulse"))
+    return "Zoom key pulse";
+  if (!strcmp(id, "focus_pulse"))
+    return "Focus key pulse";
+  return "Reset TUI settings";
+}
+static const char *tui_description(const char *id) {
+  if (!strcmp(id, "tui_settings"))
+    return "Configure keyboard movement pulse durations.";
+  if (!strcmp(id, "pan_pulse"))
+    return "Duration added by each W/A/S/D key press.";
+  if (!strcmp(id, "zoom_pulse"))
+    return "Duration added by each Z/X key press.";
+  if (!strcmp(id, "focus_pulse"))
+    return "Duration added by each N/F key press.";
+  return "Restore all TUI pulse durations to their defaults.";
+}
+static unsigned *tui_value(struct pct_tui_settings *s, const char *id) {
+  if (!strcmp(id, "pan_pulse"))
+    return &s->pan_pulse;
+  if (!strcmp(id, "zoom_pulse"))
+    return &s->zoom_pulse;
+  if (!strcmp(id, "focus_pulse"))
+    return &s->focus_pulse;
+  return NULL;
+}
+static unsigned tui_default(const char *id) {
+  if (!strcmp(id, "pan_pulse"))
+    return 250;
+  if (!strcmp(id, "zoom_pulse"))
+    return 300;
+  return 120;
+}
+static void save_tui_value(struct pct_ui_context *ui, const char *id,
+                           unsigned value) {
+  char text[32], err[128];
+  snprintf(text, sizeof(text), "%u", value);
+  mkdir("/etc/pelcodtui", 0755);
+  if (pct_state_write(ui->state_path, "app", id, text, "tui setting", err,
+                      sizeof(err)))
+    snprintf(ui->message, sizeof(ui->message), "Save failed: %s", err);
+  else
+    snprintf(ui->message, sizeof(ui->message), "Saved %s=%ums", id, value);
+}
+static void configure_tui(struct pct_ui_context *ui,
+                          struct pct_tui_settings *s, const struct item *i) {
+  if (i->action) {
+    if (!confirm_dialog(ui, "Reset all TUI pulse durations?"))
+      return;
+    s->pan_pulse = 250;
+    s->zoom_pulse = 300;
+    s->focus_pulse = 120;
+    save_tui_value(ui, "pan_pulse", s->pan_pulse);
+    save_tui_value(ui, "zoom_pulse", s->zoom_pulse);
+    save_tui_value(ui, "focus_pulse", s->focus_pulse);
+    snprintf(ui->message, sizeof(ui->message), "TUI settings reset");
+    return;
+  }
+  unsigned *v = tui_value(s, i->id);
+  echo();
+  curs_set(1);
+  mvprintw(LINES - 2, 2, "Pulse duration 20..2000 ms: ");
+  clrtoeol();
+  char b[16] = "";
+  int input_result = getnstr(b, 15);
+  noecho();
+  curs_set(0);
+  if (input_result == ERR)
+    return;
+  char *end = NULL;
+  unsigned long n = strtoul(b, &end, 10);
+  if (!end || *end || n < 20 || n > 2000) {
+    snprintf(ui->message, sizeof(ui->message), "Pulse must be 20..2000 ms");
+    return;
+  }
+  *v = (unsigned)n;
+  save_tui_value(ui, i->id, *v);
+}
+
+int pct_ui_picker(struct pct_ui_context *ui, char *out, size_t n) {
+  const char *profiles_dir = ui->profiles_dir;
+  DIR *d = opendir(profiles_dir);
+  if (!d) {
+    profiles_dir = "./cameras";
+    d = opendir(profiles_dir);
+  }
+  char paths[32][256], names[32][96];
+  int count = 0, sel = 0;
+  struct dirent *e;
+  if (d) {
+    while ((e = readdir(d)) && count < 31) {
+      size_t l = strlen(e->d_name);
+      if (l > 5 && !strcmp(e->d_name + l - 5, ".conf")) {
+        snprintf(paths[count], 256, "%s/%s", profiles_dir, e->d_name);
+        struct pct_profile p;
+        char er[128];
+        if (!pct_profile_load(&p, paths[count], er, sizeof(er)))
+          snprintf(names[count++], 96, "%s",
+                   pct_ui_nz(pct_get(&p, "profile", "name"), e->d_name));
+      }
+    }
+    closedir(d);
+  }
+  snprintf(names[count], 96, "My camera is not in the list");
+  paths[count][0] = 0;
+  count++;
+  for (;;) {
+    erase();
+    mvprintw(2, 4, "No known camera state exists");
+    mvprintw(4, 4, "Pelco-D cannot read settings back from the camera.");
+    mvprintw(6, 4, "Select a camera profile:");
+    for (int i = 0; i < count; i++) {
+      if (i == sel)
+        attron(A_REVERSE);
+      mvprintw(8 + i, 6, "%s", names[i]);
+      if (i == sel)
+        attroff(A_REVERSE);
+    }
+    refresh();
+    int c = getch();
+    if (pct_ui_shutdown(ui))
+      return -1;
+    if (c == KEY_UP && sel)
+      sel--;
+    else if (c == KEY_DOWN && sel < count - 1)
+      sel++;
+    else if (c == '\n') {
+      snprintf(out, n, "%s", paths[sel]);
+      return paths[sel][0] ? 0 : 1;
+    } else if (c == 'q' || c == 27)
+      return -1;
+  }
+}
+static int print_wrapped(WINDOW *w, int y, int x, int width, int max_lines,
+                         const char *text) {
+  int lines = 0;
+  while (*text && lines < max_lines) {
+    while (*text == ' ')
+      text++;
+    size_t available = strcspn(text, "\n"), take = available;
+    if (take > (size_t)width) {
+      take = (size_t)width;
+      while (take && !isspace((unsigned char)text[take]))
+        take--;
+      if (!take)
+        take = (size_t)width;
+    }
+    size_t visible = take;
+    while (visible && isspace((unsigned char)text[visible - 1]))
+      visible--;
+    mvwaddnstr(w, y + lines++, x, text, (int)visible);
+    text += take;
+    while (*text == ' ')
+      text++;
+    if (*text == '\n')
+      text++;
+  }
+  return lines;
+}
+
+static int confirm_dialog(struct pct_ui_context *ui, const char *text) {
+  int rows, cols;
+  getmaxyx(stdscr, rows, cols);
+  int height = 9, width = cols > 70 ? 70 : cols - 4;
+  WINDOW *w = newwin(height, width, (rows - height) / 2,
+                     (cols - width) / 2);
+  box(w, 0, 0);
+  print_wrapped(w, 1, 2, width - 4, height - 4, text);
+  mvwprintw(w, height - 2, 2,
+            "Press y to continue, any other key to cancel");
+  wrefresh(w);
+  int c = wgetch(w);
+  delwin(w);
+  return !pct_ui_shutdown(ui) && (c == 'y' || c == 'Y');
+}
+static int choose_value(struct pct_ui_context *ui, const struct pct_profile *p,
+                        const struct item *i,
+                        char *out, size_t n) {
+  const char *type = pct_get(p, i->section, "type");
+  if (!strcmp(type, "number")) {
+    echo();
+    curs_set(1);
+    mvprintw(LINES - 2, 2, "Value (%s..%s %s): ", pct_get(p, i->section, "min"),
+             pct_get(p, i->section, "max"),
+             pct_ui_nz(pct_get(p, i->section, "unit"), ""));
+    clrtoeol();
+    char b[32] = "";
+    int input_result = getnstr(b, 31);
+    noecho();
+    curs_set(0);
+    if (input_result == ERR)
+      return -1;
+    snprintf(out, n, "%s", b);
+    return 0;
+  }
+  const char *opts = pct_get(p, i->section, "options");
+  char b[PCT_TEXT], vals[16][64];
+  int c = 0, sel = 0;
+  snprintf(b, sizeof(b), "%s", opts);
+  char *sv = NULL;
+  for (char *x = strtok_r(b, ",", &sv); x && c < 16;
+       x = strtok_r(NULL, ",", &sv)) {
+    while (*x == ' ')
+      x++;
+    snprintf(vals[c++], 64, "%s", x);
+  }
+  for (;;) {
+    mvprintw(LINES - 2, 2, "Choose: ");
+    clrtoeol();
+    for (int j = 0; j <= c; j++) {
+      if (j == sel)
+        attron(A_REVERSE);
+      const char *label = "Cancel";
+      char key[160];
+      if (j < c) {
+        snprintf(key, sizeof(key), "option.%.63s.label", vals[j]);
+        label = pct_ui_nz(pct_get(p, i->section, key), vals[j]);
+      }
+      printw(" %s ", label);
+      if (j == sel)
+        attroff(A_REVERSE);
+    }
+    refresh();
+    int k = getch();
+    if (pct_ui_shutdown(ui))
+      return -1;
+    if ((k == KEY_LEFT || k == KEY_UP) && sel)
+      sel--;
+    else if ((k == KEY_RIGHT || k == KEY_DOWN) && sel < c)
+      sel++;
+    else if (k == '\n') {
+      if (sel == c)
+        return -1;
+      snprintf(out, n, "%s", vals[sel]);
+      return 0;
+    } else if (k == 27)
+      return -1;
+  }
+}
+static void apply_item(struct pct_ui_context *ui, const struct pct_profile *p,
+                       const struct item *i,
+                       const struct pct_transport *t) {
+  char value[128] = "action", cmd[PCT_TEXT], err[160];
+  const char *confirm = pct_get(p, i->section, "confirm");
+  if (confirm && !strcmp(confirm, "true") &&
+      !confirm_dialog(ui, pct_ui_nz(pct_get(p, i->section, "warning"),
+                         "This action can change camera state."))) {
+    snprintf(ui->message, sizeof(ui->message), "Cancelled");
+    return;
+  }
+  if (i->action)
+    snprintf(cmd, sizeof(cmd), "%s", pct_get(p, i->section, "command"));
+  else {
+    if (choose_value(ui, p, i, value, sizeof(value)))
+      return;
+    if (pct_expand_setting(p, i->id, value, cmd, sizeof(cmd), err,
+                           sizeof(err))) {
+      snprintf(ui->message, sizeof(ui->message), "%s", err);
+      return;
+    }
+  }
+  if (pct_execute(t, cmd, ui->message, sizeof(ui->message)))
+    return;
+  if (t->dry_run)
+    return;
+  mkdir("/etc/pelcodtui", 0755);
+  if (pct_state_write(ui->state_path, pct_get(p, "profile", "id"), i->id, value,
+                      cmd, err, sizeof(err)))
+    snprintf(ui->message, sizeof(ui->message), "Sent, but %s", err);
+}
+
+static void draw_setting_details(struct pct_ui_context *ui,
+                                 const struct pct_profile *p,
+                                 const struct item *item, int x) {
+  if (item->preset) {
+    attron(COLOR_PAIR(1));
+    mvprintw(3, x, "Category: %s", item->menu);
+    attroff(COLOR_PAIR(1));
+    mvprintw(4, x, "Preset control");
+    mvprintw(6, x, "Set or call any Pelco-D preset from 1 through 255.");
+    mvprintw(9, x, "Press Enter to open preset control");
+    return;
+  }
+  const char *label = pct_ui_nz(pct_get(p, item->section, "label"), item->id);
+  const char *desc = pct_ui_nz(pct_get(p, item->section, "description"), "");
+  attron(COLOR_PAIR(1));
+  mvprintw(3, x, "Category: %s", item->menu);
+  attroff(COLOR_PAIR(1));
+  mvprintw(4, x, "%s", label);
+  int max_desc_lines = LINES - 16;
+  if (max_desc_lines < 1)
+    max_desc_lines = 1;
+  int desc_lines = print_wrapped(stdscr, 6, x, COLS - x - 2,
+                                 max_desc_lines, desc);
+  int state_y = 6 + desc_lines + 1;
+  if (state_y < 9)
+    state_y = 9;
+
+  struct pct_state_record record;
+  if (!pct_state_read(ui->state_path, pct_get(p, "profile", "id"), item->id,
+                      &record)) {
+    mvprintw(state_y, x, "Last sent: %s", record.value);
+    mvprintw(state_y + 1, x, "At: %s", record.timestamp);
+    mvprintw(state_y + 2, x, "Not confirmed by camera");
+  } else {
+    mvprintw(state_y, x, "Last sent: unknown");
+  }
+}
+
+static void camera_category_menu(struct pct_ui_context *ui,
+                                 const struct pct_profile *p,
+                                 const struct pct_transport *t,
+                                 struct item *items, int count,
+                                 const char *category) {
+  int indexes[MAX_ITEMS], item_count = 0, sel = 0;
+  for (int i = 0; i < count; i++)
+    if (!items[i].tui && !strcmp(items[i].menu, category))
+      indexes[item_count++] = i;
+
+  timeout(-1);
+  for (;;) {
+    erase();
+    int split = COLS / 2;
+    if (split < 38)
+      split = 38;
+    pct_ui_draw_areas(split);
+    attron(COLOR_PAIR(1) | A_BOLD);
+    mvprintw(0, 2, "pelcodtui");
+    attroff(COLOR_PAIR(1) | A_BOLD);
+    printw("  Camera settings  >  %s", category);
+
+    for (int i = 0; i < item_count && i < LINES - 7; i++) {
+      const struct item *item = &items[indexes[i]];
+      const char *label = item->preset
+                              ? "Preset control"
+                              : pct_ui_nz(pct_get(p, item->section, "label"), item->id);
+      if (i == sel)
+        attron(A_REVERSE);
+      mvprintw(3 + i, 2, "%-*.*s", split - 4, split - 4, label);
+      if (i == sel)
+        attroff(A_REVERSE);
+    }
+    if (item_count)
+      draw_setting_details(ui, p, &items[indexes[sel]], split + 1);
+    attron(COLOR_PAIR(2));
+    mvprintw(LINES - 4, 2, "%.*s", COLS - 4, ui->message);
+    attroff(COLOR_PAIR(2));
+    mvprintw(LINES - 2, 2, "Enter select  Q back");
+    refresh();
+
+    int c = getch();
+    if (pct_ui_shutdown(ui) || c == 'q' || c == 'Q' || c == 27)
+      break;
+    if (c == KEY_UP && sel)
+      sel--;
+    else if (c == KEY_DOWN && sel < item_count - 1)
+      sel++;
+    else if (c == '\n' && item_count) {
+      struct item *item = &items[indexes[sel]];
+      if (item->preset) {
+        pct_ui_preset_menu(ui, t, false, p);
+        timeout(-1);
+      } else {
+        apply_item(ui, p, item, t);
+      }
+    }
+  }
+}
+
+void pct_ui_camera_settings_menu(struct pct_ui_context *ui,
+                                 const struct pct_profile *p,
+                                 const struct pct_transport *t) {
+  struct item items[MAX_ITEMS];
+  int count = collect(p, items);
+  char categories[32][64];
+  int category_count = 0, sel = 0;
+  for (int i = 0; i < count; i++) {
+    if (items[i].tui)
+      continue;
+    bool found = false;
+    for (int j = 0; j < category_count; j++)
+      if (!strcmp(categories[j], items[i].menu))
+        found = true;
+    if (!found && category_count < 32)
+      snprintf(categories[category_count++], sizeof(categories[0]), "%s",
+               items[i].menu);
+  }
+
+  timeout(-1);
+  for (;;) {
+    erase();
+    int split = COLS / 2;
+    if (split < 38)
+      split = 38;
+    pct_ui_draw_areas(split);
+    attron(COLOR_PAIR(1) | A_BOLD);
+    mvprintw(0, 2, "pelcodtui");
+    attroff(COLOR_PAIR(1) | A_BOLD);
+    printw("  Camera settings");
+    for (int i = 0; i < category_count; i++) {
+      if (i == sel)
+        attron(A_REVERSE);
+      mvprintw(3 + i, 2, "%-*.*s", split - 4, split - 4, categories[i]);
+      if (i == sel)
+        attroff(A_REVERSE);
+    }
+    if (category_count) {
+      attron(COLOR_PAIR(1));
+      mvprintw(3, split + 1, "Category");
+      attroff(COLOR_PAIR(1));
+      mvprintw(5, split + 1, "%s", categories[sel]);
+      int entries = 0;
+      for (int i = 0; i < count; i++)
+        if (!items[i].tui && !strcmp(items[i].menu, categories[sel]))
+          entries++;
+      mvprintw(7, split + 1, "%d setting%s", entries,
+               entries == 1 ? "" : "s");
+    }
+    attron(COLOR_PAIR(2));
+    mvprintw(LINES - 4, 2, "%.*s", COLS - 4, ui->message);
+    attroff(COLOR_PAIR(2));
+    mvprintw(LINES - 2, 2, "Enter open  Q back");
+    refresh();
+
+    int c = getch();
+    if (pct_ui_shutdown(ui) || c == 'q' || c == 'Q' || c == 27)
+      break;
+    if (c == KEY_UP && sel)
+      sel--;
+    else if (c == KEY_DOWN && sel < category_count - 1)
+      sel++;
+    else if (c == '\n' && category_count) {
+      camera_category_menu(ui, p, t, items, count, categories[sel]);
+      timeout(-1);
+    }
+  }
+  timeout(20);
+}
+
+int pct_ui_preset_menu(struct pct_ui_context *ui,
+                       const struct pct_transport *t, bool camera_key,
+                       const struct pct_profile *p) {
+  char number[4] = "", action[5] = "Call";
+  size_t len = 0;
+  timeout(-1);
+  for (;;) {
+    erase();
+    attron(COLOR_PAIR(1) | A_BOLD);
+    mvprintw(1, 2, "pelcodtui");
+    attroff(COLOR_PAIR(1) | A_BOLD);
+    printw("  Preset control");
+    mvprintw(4, 4, "Type a number: range 1..255,");
+    mvprintw(5, 4, "press S for Set or C for Call, then Enter.");
+    mvprintw(8, 4, "Preset number: [%-3s]  Current action: %s", number, action);
+    attron(COLOR_PAIR(2));
+    mvprintw(11, 4, "%s", ui->message);
+    attroff(COLOR_PAIR(2));
+    mvprintw(LINES - 2, 2, "%s", camera_key ? "Esc camera  Q quit" : "Q back");
+    refresh();
+    int c = getch();
+    if (pct_ui_shutdown(ui))
+      return 0;
+    if (c == 'q' || c == 'Q')
+      return 0;
+    if (c == 27)
+      return camera_key ? 2 : 0;
+    if (c >= '0' && c <= '9' && len < 3) {
+      number[len++] = (char)c;
+      number[len] = 0;
+    } else if ((c == KEY_BACKSPACE || c == 127 || c == 8) && len) {
+      number[--len] = 0;
+    } else if (c == 's' || c == 'S') {
+      snprintf(action, sizeof(action), "Set");
+    } else if (c == 'c' || c == 'C') {
+      snprintf(action, sizeof(action), "Call");
+    } else if (c == '\n') {
+      int preset = atoi(number);
+      if (preset < 1 || preset > 255) {
+        snprintf(ui->message, sizeof(ui->message), "Preset must be 1..255");
+        continue;
+      }
+      char cmd[64];
+      const char *dangerous = p ? pct_get(p, "profile",
+          !strcmp(action, "Set") ? "dangerous_set" : "dangerous_call") : NULL;
+      char preset_text[4];
+      snprintf(preset_text, sizeof(preset_text), "%d", preset);
+      if (pct_csv_has(dangerous, preset_text) &&
+          !confirm_dialog(ui, "This preset command can reset or delete controller state."))
+        continue;
+      snprintf(cmd, sizeof(cmd), "preset_%s %d",
+               !strcmp(action, "Set") ? "set" : "call", preset);
+      pct_execute(t, cmd, ui->message, sizeof(ui->message));
+    }
+  }
+}
+
+void pct_ui_settings_menu(struct pct_ui_context *ui,
+                          struct pct_tui_settings *settings) {
+  const char *ids[] = {"pan_pulse", "zoom_pulse", "focus_pulse", "reset"};
+  int sel = 0;
+  timeout(-1);
+  for (;;) {
+    erase();
+    int split = COLS / 2;
+    if (split < 38)
+      split = 38;
+    pct_ui_draw_areas(split);
+    attron(COLOR_PAIR(1) | A_BOLD);
+    mvprintw(0, 2, "pelcodtui");
+    attroff(COLOR_PAIR(1) | A_BOLD);
+    printw("  TUI settings");
+
+    for (int i = 0; i < 4; i++) {
+      if (i == sel)
+        attron(A_REVERSE);
+      mvprintw(4 + i, 3, "%-*.*s", split - 5, split - 5, tui_label(ids[i]));
+      if (i == sel)
+        attroff(A_REVERSE);
+    }
+    int x = split + 1;
+    mvprintw(3, x, "TUI settings");
+    mvprintw(5, x, "%.*s", COLS - x - 2, tui_description(ids[sel]));
+    unsigned *value = tui_value(settings, ids[sel]);
+    if (value) {
+      mvprintw(8, x, "Current: %u ms", *value);
+      mvprintw(9, x, "Default: %u ms", tui_default(ids[sel]));
+    } else {
+      mvprintw(8, x, "Pan 250 ms, zoom 300 ms, focus 120 ms");
+    }
+    attron(COLOR_PAIR(2));
+    mvprintw(LINES - 4, 2, "%.*s", COLS - 4, ui->message);
+    attroff(COLOR_PAIR(2));
+    mvprintw(LINES - 2, 2, "Enter change  Q back");
+    refresh();
+    int c = getch();
+    if (pct_ui_shutdown(ui))
+      break;
+    if (c == 'q' || c == 'Q' || c == 27)
+      break;
+    if (c == KEY_UP && sel)
+      sel--;
+    else if (c == KEY_DOWN && sel < 3)
+      sel++;
+    else if (c == '\n') {
+      struct item item = {.tui = true, .action = sel == 3};
+      snprintf(item.id, sizeof(item.id), "%s", ids[sel]);
+      configure_tui(ui, settings, &item);
+    }
+  }
+  timeout(20);
+}

--- a/pelcodtui/tests/test_core.c
+++ b/pelcodtui/tests/test_core.c
@@ -1,0 +1,394 @@
+#include "pelcodtui.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <pty.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+static void read_exact(int fd, uint8_t *out, size_t n) {
+  size_t off = 0;
+  while (off < n) {
+    ssize_t r = read(fd, out + off, n - off);
+    assert(r > 0);
+    off += (size_t)r;
+  }
+}
+
+static void clear_lock(void) {
+  rmdir("/tmp/btzoom.lock");
+}
+
+static void set_entry(struct pct_profile *p, const char *section,
+                      const char *key, const char *value) {
+  for (size_t i = 0; i < p->count; i++) {
+    if (!strcmp(p->entries[i].section, section) &&
+        !strcmp(p->entries[i].key, key)) {
+      snprintf(p->entries[i].value, sizeof(p->entries[i].value), "%s", value);
+      return;
+    }
+  }
+  assert(0 && "profile entry not found");
+}
+
+static void frame_tests(void) {
+  uint8_t f[7];
+  const uint8_t set[] = {0xff, 1, 0, 3, 0, 121, 125};
+  const uint8_t call[] = {0xff, 1, 0, 7, 0, 120, 128};
+  const uint8_t stop[] = {0xff, 1, 0, 0, 0, 0, 1};
+  static const struct {
+    const char *verb;
+    unsigned speed;
+    uint8_t frame[7];
+  } motions[] = {
+      {"left", 30, {0xff, 1, 0, 0x04, 30, 0, 35}},
+      {"right", 30, {0xff, 1, 0, 0x02, 30, 0, 33}},
+      {"up", 30, {0xff, 1, 0, 0x08, 0, 30, 39}},
+      {"down", 30, {0xff, 1, 0, 0x10, 0, 30, 47}},
+      {"tele", 0, {0xff, 1, 0, 0x20, 0, 0, 33}},
+      {"wide", 0, {0xff, 1, 0, 0x40, 0, 0, 65}},
+      {"near", 0, {0xff, 1, 0x01, 0, 0, 0, 2}},
+      {"far", 0, {0xff, 1, 0, 0x80, 0, 0, 129}},
+  };
+  pct_frame_preset(1, "set", 121, f);
+  assert(!memcmp(f, set, 7));
+  pct_frame_preset(1, "call", 120, f);
+  assert(!memcmp(f, call, 7));
+  pct_frame_stop(1, f);
+  assert(!memcmp(f, stop, 7));
+  for (size_t i = 0; i < sizeof(motions) / sizeof(motions[0]); i++) {
+    pct_frame_motion(1, motions[i].verb, motions[i].speed, f);
+    assert(!memcmp(f, motions[i].frame, 7));
+  }
+}
+
+static void uart_sequence_test(void) {
+  int master, slave;
+  char name[128], summary[128];
+  assert(!openpty(&master, &slave, name, NULL, NULL));
+  close(slave);
+  struct pct_transport t = {.baud = 115200, .address = 1,
+      .sequence_delay_ms = 1, .stop_repeat = 3, .stop_delay_ms = 1};
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  clear_lock();
+  assert(!pct_execute(&t, "preset_set 115; preset_set 7", summary,
+                      sizeof(summary)));
+  uint8_t got[14], first[7], second[7];
+  pct_frame_preset(1, "set", 115, first);
+  pct_frame_preset(1, "set", 7, second);
+  read_exact(master, got, sizeof(got));
+  assert(!memcmp(got, first, 7));
+  assert(!memcmp(got + 7, second, 7));
+  close(master);
+}
+
+static void command_rejection_test(void) {
+  struct pct_transport t = {.baud = 115200, .address = 1,
+                            .stop_repeat = 3, .dry_run = true};
+  char summary[128];
+  clear_lock();
+  assert(pct_execute(&t, "preset_call 10 garbage", summary, sizeof(summary)));
+  assert(pct_execute(&t, "preset_call 0", summary, sizeof(summary)));
+  assert(pct_execute(&t, ";;;", summary, sizeof(summary)));
+}
+
+static void stale_lock_test(void) {
+  int master, slave;
+  char name[128], summary[128];
+  assert(!openpty(&master, &slave, name, NULL, NULL));
+  close(slave);
+  struct pct_transport t = {.baud = 115200, .address = 1};
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  clear_lock();
+  assert(!mkdir("/tmp/btzoom.lock", 0700));
+  struct timespec stale[2] = {{.tv_sec = time(NULL) - 61},
+                              {.tv_sec = time(NULL) - 61}};
+  assert(!utimensat(AT_FDCWD, "/tmp/btzoom.lock", stale, 0));
+  assert(!pct_execute(&t, "preset_call 1", summary, sizeof(summary)));
+  uint8_t got[7], expected[] = {0xff, 1, 0, 7, 0, 1, 9};
+  read_exact(master, got, sizeof(got));
+  assert(!memcmp(got, expected, sizeof(got)));
+  close(master);
+}
+
+static void dry_run_lock_test(void) {
+  struct pct_transport t = {.baud = 115200, .address = 1,
+                            .stop_repeat = 3, .dry_run = true};
+  char summary[128];
+  clear_lock();
+  assert(!mkdir("/tmp/btzoom.lock", 0700));
+  assert(!pct_execute(&t, "preset_call 1", summary, sizeof(summary)));
+  struct pct_motion m = {.fd = -1};
+  assert(!pct_motion_start(&m, &t, "tele", 0, summary, sizeof(summary)));
+  assert(!pct_motion_stop(&m, summary, sizeof(summary)));
+  assert(!rmdir("/tmp/btzoom.lock"));
+}
+
+static void motion_test(void) {
+  int master, slave;
+  char name[128], summary[128];
+  assert(!openpty(&master, &slave, name, NULL, NULL));
+  close(slave);
+  struct pct_transport t = {.baud = 115200, .address = 1,
+      .stop_repeat = 3, .stop_delay_ms = 1};
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  clear_lock();
+  struct pct_motion m = {.fd = -1};
+  assert(!pct_motion_start(&m, &t, "tele", 0, summary, sizeof(summary)));
+  assert(access("/tmp/btzoom.lock/pelcodtui.pid", F_OK) < 0);
+  assert(m.fd >= 0);
+  struct termios settings;
+  assert(!tcgetattr(m.fd, &settings));
+  assert(!(settings.c_cflag & (PARENB | CSTOPB)));
+  assert((settings.c_cflag & CSIZE) == CS8);
+#ifdef CRTSCTS
+  assert(!(settings.c_cflag & CRTSCTS));
+#endif
+  assert(!pct_motion_stop(&m, summary, sizeof(summary)));
+  assert(m.fd == -1);
+  uint8_t got[28], start[7], stop[7];
+  pct_frame_motion(1, "tele", 0, start);
+  pct_frame_stop(1, stop);
+  read_exact(master, got, sizeof(got));
+  assert(!memcmp(got, start, 7));
+  for (int i = 1; i < 4; i++)
+    assert(!memcmp(got + i * 7, stop, 7));
+  close(master);
+}
+
+static void motion_switch_test(void) {
+  int master, slave;
+  char name[128], summary[128];
+  assert(!openpty(&master, &slave, name, NULL, NULL));
+  close(slave);
+  struct pct_transport t = {.baud = 115200, .address = 1,
+                            .stop_repeat = 3, .stop_delay_ms = 1};
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  clear_lock();
+  struct pct_motion m = {.fd = -1};
+  assert(!pct_motion_start(&m, &t, "left", 30, summary, sizeof(summary)));
+  assert(!pct_motion_stop(&m, summary, sizeof(summary)));
+  assert(!pct_motion_start(&m, &t, "tele", 0, summary, sizeof(summary)));
+  assert(!pct_motion_stop(&m, summary, sizeof(summary)));
+
+  uint8_t got[56], left[7], tele[7], stop[7];
+  pct_frame_motion(1, "left", 30, left);
+  pct_frame_motion(1, "tele", 0, tele);
+  pct_frame_stop(1, stop);
+  read_exact(master, got, sizeof(got));
+  assert(!memcmp(got, left, 7));
+  for (int i = 1; i < 4; i++)
+    assert(!memcmp(got + i * 7, stop, 7));
+  assert(!memcmp(got + 28, tele, 7));
+  for (int i = 5; i < 8; i++)
+    assert(!memcmp(got + i * 7, stop, 7));
+  close(master);
+}
+
+static void recovered_stop_test(void) {
+  int master, slave;
+  char name[128], summary[128];
+  assert(!openpty(&master, &slave, name, NULL, NULL));
+  close(slave);
+  struct pct_transport t = {.baud = 115200, .address = 1,
+                            .stop_repeat = 3, .stop_delay_ms = 1};
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  clear_lock();
+  struct pct_motion m = {.fd = -1};
+  assert(!pct_motion_start(&m, &t, "tele", 0, summary, sizeof(summary)));
+  assert(m.fd >= 0);
+  close(m.fd);
+  assert(!pct_motion_stop(&m, summary, sizeof(summary)));
+  assert(!strcmp(summary, "stopped (2/3 STOP frames)"));
+  assert(!m.active);
+  assert(m.fd == -1);
+
+  uint8_t got[21];
+  const uint8_t tele[] = {0xff, 1, 0, 0x20, 0, 0, 33};
+  const uint8_t stop[] = {0xff, 1, 0, 0, 0, 0, 1};
+  read_exact(master, got, sizeof(got));
+  assert(!memcmp(got, tele, 7));
+  assert(!memcmp(got + 7, stop, 7));
+  assert(!memcmp(got + 14, stop, 7));
+  close(master);
+}
+
+static void failed_stop_test(void) {
+  int master, slave;
+  char name[128], summary[128];
+  assert(!openpty(&master, &slave, name, NULL, NULL));
+  close(slave);
+  struct pct_transport t = {.baud = 115200, .address = 1,
+                            .stop_repeat = 3};
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  clear_lock();
+  struct pct_motion m = {.fd = -1};
+  assert(!pct_motion_start(&m, &t, "tele", 0, summary, sizeof(summary)));
+  assert(m.fd >= 0);
+  close(m.fd);
+  m.fd = -1;
+  snprintf(t.device, sizeof(t.device), "/missing-pelcodtui-uart");
+  assert(pct_motion_stop(&m, summary, sizeof(summary)));
+  assert(m.active);
+  assert(m.fd == -1);
+
+  int replacement_master, replacement_slave;
+  assert(!openpty(&replacement_master, &replacement_slave, name, NULL, NULL));
+  close(replacement_slave);
+  snprintf(t.device, sizeof(t.device), "%s", name);
+  assert(!pct_motion_stop(&m, summary, sizeof(summary)));
+  assert(!m.active);
+  assert(m.fd == -1);
+  close(replacement_master);
+  clear_lock();
+  close(master);
+}
+
+static void execute_dry(const char *command) {
+  struct pct_transport t = {.baud = 115200, .address = 1,
+                            .stop_repeat = 3, .dry_run = true};
+  char summary[128];
+  clear_lock();
+  assert(!pct_execute(&t, command, summary, sizeof(summary)));
+}
+
+static void all_profile_commands_test(const struct pct_profile *p) {
+  char command[PCT_TEXT], err[128];
+  for (size_t i = 0; i < p->section_count; i++) {
+    const char *section = p->sections[i];
+    if (!strncmp(section, "action.", 7)) {
+      execute_dry(pct_get(p, section, "command"));
+      continue;
+    }
+    if (strncmp(section, "setting.", 8))
+      continue;
+
+    const char *id = section + 8;
+    const char *type = pct_get(p, section, "type");
+    if (!strcmp(type, "number")) {
+      assert(!pct_expand_setting(p, id, pct_get(p, section, "default"), command,
+                                 sizeof(command), err, sizeof(err)));
+      execute_dry(command);
+      continue;
+    }
+
+    char options[PCT_TEXT];
+    snprintf(options, sizeof(options), "%s", pct_get(p, section, "options"));
+    char *save = NULL;
+    for (char *option = strtok_r(options, ",", &save); option;
+         option = strtok_r(NULL, ",", &save)) {
+      while (*option == ' ')
+        option++;
+      assert(!pct_expand_setting(p, id, option, command, sizeof(command), err,
+                                 sizeof(err)));
+      execute_dry(command);
+    }
+  }
+}
+
+static void state_test(const char *id) {
+  const char *path = "/tmp/pelcodtui-test-state.conf";
+  char err[128];
+  unlink(path);
+  assert(!pct_state_write(path, id, "cruise_speed", "7",
+                          "preset_set 115; preset_set 7", err, sizeof(err)));
+  assert(!pct_state_write(path, id, "idle_delay", "5",
+                          "preset_set 132; preset_set 5", err, sizeof(err)));
+  assert(!pct_state_write(path, id, "cruise_speed", "8",
+                          "preset_set 115; preset_set 8", err, sizeof(err)));
+  struct pct_state_record updated, preserved;
+  assert(!pct_state_read(path, id, "cruise_speed", &updated));
+  assert(!strcmp(updated.value, "8"));
+  assert(!strcmp(updated.command, "preset_set 115; preset_set 8"));
+  assert(!pct_state_read(path, id, "idle_delay", &preserved));
+  assert(!strcmp(preserved.value, "5"));
+  assert(!pct_state_write(path, "app", "selection", "/missing-profile.conf",
+                          "select", err, sizeof(err)));
+  assert(!pct_state_remove(path, "app", "selection", err, sizeof(err)));
+  assert(pct_state_read(path, "app", "selection", &updated));
+  assert(!pct_state_read(path, id, "idle_delay", &preserved));
+  unlink(path);
+}
+
+static void validation_test(const struct pct_profile *source) {
+  struct pct_profile p;
+  char err[256];
+  p = *source;
+  set_entry(&p, "uart", "address", "256");
+  assert(pct_profile_validate(&p, err, sizeof(err)));
+  p = *source;
+  set_entry(&p, "uart", "baud", "7200");
+  assert(pct_profile_validate(&p, err, sizeof(err)));
+  p = *source;
+  set_entry(&p, "setting.cruise_speed", "command",
+            "preset_set 115 garbage");
+  assert(pct_profile_validate(&p, err, sizeof(err)));
+  p = *source;
+  set_entry(&p, "setting.cruise_speed", "command", ";;;");
+  assert(pct_profile_validate(&p, err, sizeof(err)));
+  p = *source;
+  set_entry(&p, "menu.cruise", "items", "missing_item");
+  assert(pct_profile_validate(&p, err, sizeof(err)));
+}
+
+static void repeated_value_test(const struct pct_profile *source) {
+  struct pct_profile p = *source;
+  char command[PCT_TEXT], err[128];
+  set_entry(&p, "setting.cruise_speed", "command",
+            "preset_set $value; preset_call $value");
+  assert(!pct_profile_validate(&p, err, sizeof(err)));
+  assert(!pct_expand_setting(&p, "cruise_speed", "7", command,
+                             sizeof(command), err, sizeof(err)));
+  assert(!strcmp(command, "preset_set 7; preset_call 7"));
+}
+
+int main(int argc, char **argv) {
+  assert(argc == 2);
+  char err[256], cmd[512];
+  struct pct_profile p;
+  assert(!pct_profile_load(&p, argv[1], err, sizeof(err)));
+  const char *id = pct_get(&p, "profile", "id");
+  assert(id);
+  assert(!pct_expand_setting(&p, "cruise_speed", "7", cmd, sizeof(cmd), err,
+                             sizeof(err)));
+  assert(!strcmp(cmd, "preset_set 115; preset_set 7"));
+  assert(pct_expand_setting(&p, "cruise_speed", "11", cmd, sizeof(cmd), err,
+                            sizeof(err)));
+  if (!strcmp(id, "p35-hieasy")) {
+    assert(!pct_expand_setting(&p, "cruise_dwell", "10s", cmd, sizeof(cmd),
+                               err, sizeof(err)));
+    assert(!strcmp(cmd, "preset_set 54"));
+  } else if (!strcmp(id, "h07-hieasy")) {
+    assert(!pct_expand_setting(&p, "af_trigger", "zoom", cmd, sizeof(cmd), err,
+                               sizeof(err)));
+    assert(!strcmp(cmd, "preset_set 250; preset_call 1"));
+    assert(!pct_expand_setting(&p, "ir_brightness", "5", cmd, sizeof(cmd), err,
+                               sizeof(err)));
+    assert(!strcmp(cmd, "preset_set 122; preset_set 5"));
+    assert(pct_expand_setting(&p, "ir_brightness", "0", cmd, sizeof(cmd), err,
+                              sizeof(err)));
+    assert(pct_expand_setting(&p, "ir_brightness", "11", cmd, sizeof(cmd), err,
+                              sizeof(err)));
+  } else {
+    assert(!strcmp(id, "p6slite"));
+  }
+  validation_test(&p);
+  repeated_value_test(&p);
+  all_profile_commands_test(&p);
+  frame_tests();
+  uart_sequence_test();
+  command_rejection_test();
+  stale_lock_test();
+  dry_run_lock_test();
+  motion_test();
+  motion_switch_test();
+  recovered_stop_test();
+  failed_stop_test();
+  state_test(id);
+  puts("all tests passed");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Adds `pelcodtui`, an ncurses interface for Pelco-D camera controllers.

- Supports controller commands from camera profiles.
- Initial support for P35 HiEasy, H07 HiEasy, and P6SLite profiles.
- Saves the last command and timestamp.
- Provides presets, controller settings, manual movement, and safe STOP handling.
- Adds native tests and OpenIPC camera deployment support.

## Tests

- `make test`
- OpenIPC ARM cross-build
- Live test on a HI3516EV300 camera with a Pelco-D board